### PR TITLE
add obsolete tag to let people know we are moving

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>0.0.5</VersionPrefix>
+    <VersionPrefix>0.0.6</VersionPrefix>
 
     <Authors>Chatham Financial Corp.</Authors>
     <Copyright>Copyright 2018 (c) Chatham Financial Corp. All rights reserved.</Copyright>
@@ -14,7 +14,7 @@
     <IsPackable>false</IsPackable>
 
     <LangVersion>latest</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/LetsTrace/Tracer.cs
+++ b/src/LetsTrace/Tracer.cs
@@ -19,6 +19,7 @@ using OpenTracing.Util;
 namespace LetsTrace
 {
     // Tracer is the main object that consumers use to start spans
+    [Obsolete("LetsTrace is moving to the Jaeger org and will be changing names! Please checkout https://github.com/Chatham/LetsTrace which should redirect to the new location once the move occurs.")]
     public class Tracer : ILetsTraceTracer
     {
         private readonly ILogger _logger;


### PR DESCRIPTION
had to not error on warning as the obsolete tag makes unit test builds to error - this is temp and should be changed once we make the move