### PR TITLE
add size checking in UDP transport

### DIFF
--- a/src/Jaeger.Transport.Thrift/Transport/Internal/TMemoryBuffer.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/Internal/TMemoryBuffer.cs
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation(ASF) under one
+// or more contributor license agreements.See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Copied and modified to have a Reset method from https://github.com/apache/thrift/blob/19baeefd8c38d62085891d7956349601f79448b3/lib/netcore/Thrift/Transports/Client/TMemoryBufferClientTransport.cs
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Transports;
+
+namespace Jaeger.Transport.Thrift.Transport.Internal
+{
+    internal class TMemoryBuffer : TClientTransport
+    {
+        private readonly MemoryStream _byteStream;
+        private bool _isDisposed;
+
+        public TMemoryBuffer()
+        {
+            _byteStream = new MemoryStream();
+        }
+
+        public override bool IsOpen => true;
+
+        public override async Task OpenAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                await Task.FromCanceled(cancellationToken);
+            }
+        }
+
+        public override void Close()
+        {
+            // do nothing
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int length,
+            CancellationToken cancellationToken)
+        {
+            return await _byteStream.ReadAsync(buffer, offset, length, cancellationToken);
+        }
+
+        public override async Task WriteAsync(byte[] buffer, CancellationToken cancellationToken)
+        {
+            await _byteStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int length, CancellationToken cancellationToken)
+        {
+            await _byteStream.WriteAsync(buffer, offset, length, cancellationToken);
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                await Task.FromCanceled(cancellationToken);
+            }
+        }
+
+        public byte[] GetBuffer()
+        {
+            return _byteStream.ToArray();
+        }
+
+        public void Reset()
+        {
+            _byteStream.SetLength(0);
+        }
+
+        // IDisposable
+        protected override void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    _byteStream?.Dispose();
+                }
+            }
+            _isDisposed = true;
+        }
+    }
+}

--- a/src/Jaeger.Transport.Thrift/Transport/Internal/ThriftUdpClientTransport.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/Internal/ThriftUdpClientTransport.cs
@@ -7,7 +7,6 @@ using Thrift.Transports;
 
 namespace Jaeger.Transport.Thrift.Transport.Internal
 {
-    // TODO: TMemoryBufferClientTransport is missing a Reset method or having _byteStream protected
     internal class ThriftUdpClientTransport : TClientTransport
     {
         private readonly IUdpClient _client;

--- a/src/Jaeger.Transport.Thrift/Transport/Internal/ThriftUdpClientTransport.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/Internal/ThriftUdpClientTransport.cs
@@ -82,6 +82,10 @@ namespace Jaeger.Transport.Thrift.Transport.Internal
             {
                 return _client.SendAsync(bytes, bytes.Length);
             }
+            catch (SocketException se)
+            {
+                throw new TTransportException(TTransportException.ExceptionType.Unknown, $"Cannot flush because of socket exception. UDP Packet size was {bytes.Length}. Exception message: {se.Message}");
+            }
             catch (Exception e)
             {
                 throw new TTransportException(TTransportException.ExceptionType.Unknown, $"Cannot flush closed transport. {e.Message}");

--- a/src/Jaeger.Transport.Thrift/Transport/JaegerHTTPTransport.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/JaegerHTTPTransport.cs
@@ -21,7 +21,7 @@ namespace Jaeger.Transport.Thrift.Transport
 
         /// <inheritdoc />
         /// <param name="batchSize">The number of spans to buffer before sending them to Jaeger</param>
-        /// <param name="host">The host the Jaeger is running on</param>
+        /// <param name="host">The host that Jaeger is running on</param>
         /// <param name="port">The port of the host that Jaeger will accept http thrift</param>
         public JaegerHttpTransport(int batchSize = 0, string host = TransportConstants.DefaultAgentHost, int port = TransportConstants.DefaultCollectorHttpJaegerThriftPort) 
             : this(new Uri($"http://{host}:{port}/api/traces"), batchSize)

--- a/src/Jaeger.Transport.Thrift/Transport/JaegerHTTPTransport.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/JaegerHTTPTransport.cs
@@ -1,21 +1,73 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jaeger.Transport.Thrift.Serialization;
 using Jaeger.Transport.Thrift.Transport.Sender;
-using Thrift.Protocols;
+using JaegerSpan = Jaeger.Thrift.Span;
 
 namespace Jaeger.Transport.Thrift.Transport
 {
+    /// <inheritdoc />
+    /// <summary>
+    /// JaegerHttpTransport provides an implementation to transport spans over HTTP using
+    /// Thrift. Spans are buffered unitl reaching the BatchSize at which point all spans
+    /// in the buffer will be sent to Jaeger.
+    /// </summary>
     public class JaegerHttpTransport : JaegerThriftTransport
     {
         public Uri Uri { get; }
+        internal const int DefaultBatchSize = 100;
+        internal readonly int BatchSize;
 
-        public JaegerHttpTransport(string hostname = TransportConstants.DefaultAgentHost, int port = TransportConstants.DefaultCollectorHttpJaegerThriftPort, int bufferSize = 0) 
-            : this(new Uri($"http://{hostname}:{port}/api/traces"), bufferSize)
+        /// <inheritdoc />
+        /// <param name="batchSize">The number of spans to buffer before sending them to Jaeger</param>
+        /// <param name="host">The host the Jaeger is running on</param>
+        /// <param name="port">The port of the host that Jaeger will accept http thrift</param>
+        public JaegerHttpTransport(int batchSize = 0, string host = TransportConstants.DefaultAgentHost, int port = TransportConstants.DefaultCollectorHttpJaegerThriftPort) 
+            : this(new Uri($"http://{host}:{port}/api/traces"), batchSize)
         {
         }
 
-        protected JaegerHttpTransport(Uri uri, int bufferSize = 0) : base(new TBinaryProtocol.Factory(), new JaegerThriftHttpSender(uri), null, bufferSize)
+        /// <inheritdoc />
+        /// <param name="uri">The endpoint to send http Thrift to</param>
+        /// <param name="batchSize">The number of spans to buffer before sending them to Jaeger</param>
+        public JaegerHttpTransport(Uri uri, int batchSize = 0) : this(uri, batchSize, new JaegerThriftHttpSender(uri))
+        {
+        }
+
+        /// <inheritdoc />
+        /// <param name="uri">The endpoint to send http Thrift to</param>
+        /// <param name="batchSize">The number of spans to buffer before sending them to Jaeger</param>
+        /// <param name="sender">The ISender that will take care of the actual sending as well as storing the items to be sent</param>
+        /// <param name="serialization">The object that is used to serialize the spans into Thrift</param>
+        internal JaegerHttpTransport(Uri uri, int batchSize, ISender sender, ISerialization serialization = null)
+            : base(sender, serialization)
         {
             Uri = uri;
+            if (batchSize <= 0)
+            {
+                BatchSize = DefaultBatchSize;
+            }
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// ProtocolAppendLogicAsync contains the specific logic for appending spans to be
+        /// sent over HTTP. It will keep track of the number of spans and send them once
+        /// over the batchSize.
+        /// </summary>
+        /// <param name="span">The span serialized in Jaeger Thrift</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        internal override async Task<int> ProtocolAppendLogicAsync(JaegerSpan span, CancellationToken cancellationToken)
+        {
+            var curBuffCount = _sender.BufferItem(span);
+
+            if (curBuffCount >= BatchSize) {
+                return await _sender.FlushAsync(_process, cancellationToken);
+            }
+
+            return 0;
         }
     }
 }

--- a/src/Jaeger.Transport.Thrift/Transport/JaegerThriftTransport.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/JaegerThriftTransport.cs
@@ -39,12 +39,12 @@ namespace Jaeger.Transport.Thrift.Transport
         /// AppendAsync serializes the passed in span into Jaeger Thrift and passes it off
         /// to the sender which will buffer it to be sent. If the buffer is full enough it
         /// will be flushed and the number of spans sent will be returned. If the buffer is
-        /// not full enough, nothing will be done a 0 will be returned to indicate that 0
+        /// not full enough, nothing will be done and a 0 will be returned to indicate that 0
         /// spans were sent.
         /// </summary>
-        /// <param name="span">the span to serialize into Jaeger Thrift and buffer to be sent</param>
+        /// <param name="span">The span to serialize into Jaeger Thrift and buffer to be sent</param>
         /// <param name="cancellationToken"></param>
-        /// <returns>the number of spans flushed, if any</returns>
+        /// <returns>The number of spans flushed, if any</returns>
         public async Task<int> AppendAsync(IJaegerCoreSpan span, CancellationToken cancellationToken)
         {
             if (_process == null) {

--- a/src/Jaeger.Transport.Thrift/Transport/JaegerThriftTransport.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/JaegerThriftTransport.cs
@@ -6,31 +6,27 @@ using Jaeger.Core.Exceptions;
 using Jaeger.Core.Transport;
 using Jaeger.Transport.Thrift.Serialization;
 using Jaeger.Transport.Thrift.Transport.Sender;
-using Thrift.Protocols;
 using JaegerProcess = Jaeger.Thrift.Process;
+using JaegerSpan = Jaeger.Thrift.Span;
 
 namespace Jaeger.Transport.Thrift.Transport
 {
+    /// <summary>
+    /// JaegerThriftTransport is the base class for transporting spans from C# into Jaeger.
+    /// It provides the basic implementation of serializing spans but leaves the buffering
+    /// and sending of the serialized spans to concrete implementations.
+    /// </summary>
     public abstract class JaegerThriftTransport : ITransport
     {
-        internal const int DefaultBufferSize = 10;
-        internal readonly int BufferSize;
-
         private readonly ISerialization _jaegerThriftSerialization;
-        protected readonly ITProtocolFactory _protocolFactory;
         protected readonly ISender _sender;
         protected JaegerProcess _process;
 
-        protected internal JaegerThriftTransport(ITProtocolFactory protocolFactory, ISender sender, ISerialization serialization = null, int bufferSize = 0)
+        /// <param name="sender">The ISender that will take care of the actual sending as well as storing the items to be sent</param>
+        /// <param name="serialization">The object that is used to serialize the spans into Thrift</param>
+        protected internal JaegerThriftTransport(ISender sender, ISerialization serialization = null)
         {
-            if (bufferSize <= 0)
-            {
-                bufferSize = DefaultBufferSize;
-            }
-
-            _protocolFactory = protocolFactory;
             _sender = sender;
-            BufferSize = bufferSize;
             _jaegerThriftSerialization = serialization ?? new JaegerThriftSerialization();
         }
 
@@ -39,22 +35,43 @@ namespace Jaeger.Transport.Thrift.Transport
             _sender.Dispose();
         }
 
-        public async Task<int> AppendAsync(IJaegerCoreSpan span, CancellationToken canellationToken)
+        /// <summary>
+        /// AppendAsync serializes the passed in span into Jaeger Thrift and passes it off
+        /// to the sender which will buffer it to be sent. If the buffer is full enough it
+        /// will be flushed and the number of spans sent will be returned. If the buffer is
+        /// not full enough, nothing will be done a 0 will be returned to indicate that 0
+        /// spans were sent.
+        /// </summary>
+        /// <param name="span">the span to serialize into Jaeger Thrift and buffer to be sent</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>the number of spans flushed, if any</returns>
+        public async Task<int> AppendAsync(IJaegerCoreSpan span, CancellationToken cancellationToken)
         {
             if (_process == null) {
                 _process = _jaegerThriftSerialization.BuildJaegerProcessThrift(span.Tracer);
             }
+
             var jaegerSpan = _jaegerThriftSerialization.BuildJaegerThriftSpan(span);
 
-            var curBuffCount = _sender.BufferItem(jaegerSpan);
-
-            if (curBuffCount >= BufferSize) {
-                return await _sender.FlushAsync(_process, canellationToken);
-            }
-
-            return 0;
+            return await ProtocolAppendLogicAsync(jaegerSpan, cancellationToken);
         }
 
+        /// <summary>
+        /// ProtocolAppendLogicAsync is the internal function to be implemented by concrete
+        /// JaegerThriftTransport that handles the logic after AppendAsync serializes a span.
+        /// When implementing ProtocolAppendLogicAsync it can be assumed that _process is populated.
+        /// </summary>
+        /// <param name="span">The span serialized in Jaeger Thrift</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        internal abstract Task<int> ProtocolAppendLogicAsync(JaegerSpan span, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// FlushAsync flushes the sender buffer without checking to see if the sender has
+        /// reached the point at which we would normally flush.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
         public async Task<int> FlushAsync(CancellationToken cancellationToken)
         {
             var sentCount = 0;
@@ -71,6 +88,12 @@ namespace Jaeger.Transport.Thrift.Transport
             return sentCount;
         }
 
+        /// <summary>
+        /// CloseAsync handles flushing the buffer of spans to be sent. If the cancellation
+        /// is requested on the cancellationToken nothing will be flushed.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
         public Task<int> CloseAsync(CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -80,7 +103,5 @@ namespace Jaeger.Transport.Thrift.Transport
 
             return FlushAsync(cancellationToken);
         }
-
-        
     }
 }

--- a/src/Jaeger.Transport.Thrift/Transport/JaegerUDPTransport.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/JaegerUDPTransport.cs
@@ -95,6 +95,7 @@ namespace Jaeger.Transport.Thrift.Transport
                 }
 
                 // can't fit anything else in the buffer, flush it
+                _byteBufferSize = _processByteSize;
                 return await FlushAsync(cancellationToken);
             }
 

--- a/src/Jaeger.Transport.Thrift/Transport/JaegerUDPTransport.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/JaegerUDPTransport.cs
@@ -1,24 +1,126 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jaeger.Transport.Thrift.Serialization;
+using Jaeger.Transport.Thrift.Transport.Internal;
 using Jaeger.Transport.Thrift.Transport.Sender;
 using Thrift.Protocols;
+using JaegerSpan = Jaeger.Thrift.Span;
 
 namespace Jaeger.Transport.Thrift.Transport
 {
+    /// <inheritdoc />
+    /// <summary>
+    /// JaegerUdpTransport provides an implementation to transport spans over UDP using
+    /// Compact Thrift. It handles making sure payloads efficiently use the UDP packet
+    /// size by filling up as much of a UDP message it can before sending.
+    /// </summary>
     public class JaegerUdpTransport : JaegerThriftTransport
     {
+        private readonly TMemoryBuffer _thriftBuffer;
+        private readonly TProtocol _thriftProtocol;
+        private int _byteBufferSize;
+        private int _processByteSize;
+        private readonly int _maxByteBufferSize;
+
         /// <inheritdoc />
         /// <summary>
-        /// This constructor expects Jaeger running running on <value>DEFAULT_AGENT_UDP_HOST</value>
-        /// and port <value>DEFAULT_AGENT_UDP_COMPACT_PORT</value>
+        /// This constructor expects Jaeger running running on <value>TransportConstants.DefaultAgentHost</value>
+        /// and port <value>TransportConstants.DefaultAgentUdpJaegerCompactThriftPort</value>
         /// </summary>
-        public JaegerUdpTransport(int bufferSize = 0) : this(TransportConstants.DefaultAgentHost, TransportConstants.DefaultAgentUdpJaegerCompactThriftPort, bufferSize)
+        public JaegerUdpTransport() : this(TransportConstants.DefaultAgentHost, TransportConstants.DefaultAgentUdpJaegerCompactThriftPort)
         {
         }
 
-        /// <param name="host">Host</param>
-        /// <param name="port">Port</param>
-        /// <param name="bufferSize">Buffer size</param>
-        public JaegerUdpTransport(string host, int port, int bufferSize = 0) : base(new TCompactProtocol.Factory(), new JaegerThriftUdpSender(host, port), null, bufferSize)
+        /// <inheritdoc />
+        /// <param name="host">The host the Jaeger Agent is running on</param>
+        /// <param name="port">The port of the host that Jaeger Agent will accept compact thrift</param>
+        /// <param name="maxPacketSize">The max byte size of UDP packets to be sent to the agent</param>
+        public JaegerUdpTransport(string host, int port, int maxPacketSize = 0) : this(maxPacketSize, new JaegerThriftUdpSender(host, port), null)
         {
+        }
+
+        /// <inheritdoc />
+        /// <param name="maxPacketSize">The max byte size of UDP packets to be sent to the agent</param>
+        /// <param name="sender">The ISender that will take care of the actual sending as well as storing the items to be sent</param>
+        /// <param name="serialization">The object that is used to serialize the spans into Thrift</param>
+        internal JaegerUdpTransport(int maxPacketSize, ISender sender, ISerialization serialization = null)
+            : base(sender, serialization)
+        {
+            // Each span is first written to thriftBuffer to determine its size in bytes.
+            _thriftBuffer = new TMemoryBuffer();
+            _thriftProtocol = _sender.ProtocolFactory.GetProtocol(_thriftBuffer);
+
+            if (maxPacketSize == 0)
+            {
+                maxPacketSize = TransportConstants.UdpPacketMaxLength;
+            }
+
+            _maxByteBufferSize = maxPacketSize - TransportConstants.UdpEmitBatchOverhead;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// ProtocolAppendLogicAsync contains the specific logic for appending spans to be
+        /// sent over UDP. It will keep track of the byte size of the information to be sent
+        /// to the Jaeger Agent and make sure that it does not go over the max UDP packet size
+        /// by automatically flushing the buffer. It will throw and exception if the span is
+        /// too large to send in one UDP packet by itself.
+        /// </summary>
+        /// <param name="span">The span serialized in Jaeger Thrift</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        internal override async Task<int> ProtocolAppendLogicAsync(JaegerSpan span, CancellationToken cancellationToken)
+        {
+            if (_processByteSize == 0) {
+                _processByteSize = await CalcSizeOfSerializedThrift(_process);
+                _byteBufferSize += _processByteSize;
+            }
+
+            var spanSize = await CalcSizeOfSerializedThrift(span);
+
+            if (spanSize > _maxByteBufferSize) {
+                throw new Exception("Span too large to send over UDP");
+            }
+
+            _byteBufferSize += spanSize;
+
+            // if the span fits in the buffer, buffer it
+            if (_byteBufferSize <= _maxByteBufferSize) {
+                _sender.BufferItem(span);
+
+                // if we can potentially fit more spans in the buffer don't flush
+                if (_byteBufferSize < _maxByteBufferSize) {
+                    return 0;
+                }
+
+                // can't fit anything else in the buffer, flush it
+                return await FlushAsync(cancellationToken);
+            }
+
+            // the latest span did not fit in the buffer
+            var sent = await FlushAsync(cancellationToken);
+
+            _sender.BufferItem(span);
+            _byteBufferSize = spanSize + _processByteSize;
+
+            return sent;
+        }
+
+        /// <summary>
+        /// CalcSizeOfSerializedThrift calculates the size in bytes that a Thrift object will take up.
+        /// </summary>
+        /// <param name="thriftBase">the base Thrift object to calculate the size of</param>
+        /// <returns></returns>
+        private async Task<int> CalcSizeOfSerializedThrift(TBase thriftBase)
+        {
+            _thriftBuffer.Reset();
+            try {
+                await thriftBase.WriteAsync(_thriftProtocol, CancellationToken.None);
+            } catch (Exception e) {
+                throw new Exception("failed to calculate the size of a serialized thrift object", e);
+            }
+            return _thriftBuffer.GetBuffer().Length;
         }
     }
 }

--- a/src/Jaeger.Transport.Thrift/Transport/Sender/ISender.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/Sender/ISender.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Thrift.Protocols;
 using JaegerProcess = Jaeger.Thrift.Process;
 using JaegerSpan = Jaeger.Thrift.Span;
 
@@ -10,6 +11,7 @@ namespace Jaeger.Transport.Thrift.Transport.Sender
     // the buffer to send all spans along to the Jaeger system
     public interface ISender : IDisposable
     {
+        ITProtocolFactory ProtocolFactory { get; }
         int BufferItem(JaegerSpan item);
         Task<int> FlushAsync(JaegerProcess process, CancellationToken cancellationToken);
     }

--- a/src/Jaeger.Transport.Thrift/Transport/Sender/JaegerSender.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/Sender/JaegerSender.cs
@@ -12,11 +12,11 @@ namespace Jaeger.Transport.Thrift.Transport.Sender
     {
         protected List<JaegerSpan> _buffer = new List<JaegerSpan>();
         protected JaegerProcess _process;
-        protected readonly ITProtocolFactory _protocolFactory;
+        public ITProtocolFactory ProtocolFactory { get; }
 
         protected internal JaegerSender(ITProtocolFactory protocolFactory)
         {
-            _protocolFactory = protocolFactory;
+            ProtocolFactory = protocolFactory;
         }
 
         public void Dispose()

--- a/src/Jaeger.Transport.Thrift/Transport/Sender/JaegerThriftHTTPSender.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/Sender/JaegerThriftHTTPSender.cs
@@ -20,7 +20,7 @@ namespace Jaeger.Transport.Thrift.Transport.Sender
                 Query = TransportConstants.CollectorHttpJaegerThriftFormatParam
             }.Uri;
             var httpTransport = new THttpClientTransport(collectorUri, null);
-            _protocol = _protocolFactory.GetProtocol(httpTransport);
+            _protocol = ProtocolFactory.GetProtocol(httpTransport);
         }
 
         protected override async Task<int> SendAsync(List<JaegerSpan> spans, CancellationToken cancellationToken)

--- a/src/Jaeger.Transport.Thrift/Transport/Sender/JaegerThriftUDPSender.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/Sender/JaegerThriftUDPSender.cs
@@ -28,7 +28,7 @@ namespace Jaeger.Transport.Thrift.Transport.Sender
             }
 
             var udpThriftTransport = new ThriftUdpClientTransport(host, port);
-            _agentClient = new Agent.Client(_protocolFactory.GetProtocol(udpThriftTransport));
+            _agentClient = new Agent.Client(ProtocolFactory.GetProtocol(udpThriftTransport));
         }
 
         protected override async Task<int> SendAsync(List<JaegerSpan> spans, CancellationToken cancellationToken)

--- a/src/Jaeger.Transport.Thrift/Transport/TransportConstants.cs
+++ b/src/Jaeger.Transport.Thrift/Transport/TransportConstants.cs
@@ -15,5 +15,16 @@
         public const int DefaultCollectorHttpJaegerThriftPort = 14268;
 
         public const string CollectorHttpJaegerThriftFormatParam = "format=jaeger.thrift";
+
+        // UdpPacketMaxLength is the max size of UDP packet we want to send, this is also the max size that jaeger-agent can handle
+        public const int UdpPacketMaxLength = 65000;
+
+        // Empirically obtained constant for how many bytes in the message are used for envelope.
+        // The total datagram size is:
+        // sizeof(Span) * numSpans + processByteSize + emitBatchOverhead <= maxPacketSize
+        // There is a unit test `EmitBatchOverhead_ShouldNotGoOverOverheadConstant` that validates this number.
+        // Note that due to the use of Compact Thrift protocol, overhead grows with the number of spans
+        // in the batch, because the length of the list is encoded as varint32, as well as SeqId.
+        public const int UdpEmitBatchOverhead = 22;
     }
 }

--- a/test/Jaeger.Core.Tests/Samplers/RemoteControlledSamplerTests.cs
+++ b/test/Jaeger.Core.Tests/Samplers/RemoteControlledSamplerTests.cs
@@ -286,7 +286,7 @@ namespace Jaeger.Core.Tests.Samplers
             var updateFunc = Substitute.For<Action>();
             var pollingIntervalMs = 1000;
             var cts = new CancellationTokenSource();
-            cts.CancelAfter(2600);
+            cts.CancelAfter(2900);
 
             await RemoteControlledSampler.PollTimer(updateFunc, pollingIntervalMs, cts.Token);
 

--- a/test/Jaeger.Transport.Thrift.Tests/Transport/JaegerHttpTransportTests.cs
+++ b/test/Jaeger.Transport.Thrift.Tests/Transport/JaegerHttpTransportTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Threading;
+using Jaeger.Core;
+using Jaeger.Transport.Thrift.Serialization;
+using Jaeger.Transport.Thrift.Transport;
+using Jaeger.Transport.Thrift.Transport.Sender;
+using NSubstitute;
+using Xunit;
+using JaegerProcess = Jaeger.Thrift.Process;
+using JaegerSpan = Jaeger.Thrift.Span;
+
+namespace Jaeger.Transport.Thrift.Tests.Transport
+{
+    public class JaegerHttpTransportTests
+    {
+        private readonly ISerialization _mockJaegerThriftSerialization;
+        private readonly ISender _mockSender;
+        private readonly JaegerThriftTransport _testingTransport;
+        private readonly int _batchSize = 4;
+
+        public JaegerHttpTransportTests()
+        {
+            _mockJaegerThriftSerialization = Substitute.For<ISerialization>();
+            _mockSender = Substitute.For<ISender>();
+
+            _testingTransport = new JaegerHttpTransport(new Uri("http://localhost:14268"), _batchSize, _mockSender, _mockJaegerThriftSerialization);
+        }
+
+        [Fact]
+        public void Constructor_ShouldSetBatchSizeToDefaultIfPassedInIsZero()
+        {
+            var transport = Substitute.For<JaegerHttpTransport>(0, "host", 1234);
+
+            Assert.Equal(JaegerHttpTransport.DefaultBatchSize, transport.BatchSize);
+        }
+
+        [Fact]
+        public async void AppendAsync_ShouldFlushWhenItReachesTheBatchSize()
+        {
+            var span = Substitute.For<IJaegerCoreSpan>();
+            var tracer = Substitute.For<IJaegerCoreTracer>();
+            span.Tracer.Returns(tracer);
+            var cts = new CancellationTokenSource();
+
+            var jProcess = Substitute.For<JaegerProcess>();
+            _mockJaegerThriftSerialization.BuildJaegerProcessThrift(Arg.Is(tracer)).Returns(jProcess);
+
+            var jSpan = Substitute.For<JaegerSpan>();
+            _mockJaegerThriftSerialization.BuildJaegerThriftSpan(Arg.Is(span)).Returns(jSpan);
+
+            _mockSender.BufferItem(Arg.Is(jSpan)).Returns(_batchSize);
+            _mockSender.FlushAsync(Arg.Any<JaegerProcess>(), Arg.Any<CancellationToken>()).Returns(_batchSize);
+
+            var sent = await _testingTransport.AppendAsync(span, cts.Token);
+
+            Assert.Equal(_batchSize, sent);
+            _mockJaegerThriftSerialization.Received(1).BuildJaegerProcessThrift(Arg.Is(tracer));
+            _mockJaegerThriftSerialization.Received(1).BuildJaegerThriftSpan(Arg.Is(span));
+            _mockSender.Received(1).BufferItem(Arg.Is(jSpan));
+            await _mockSender.Received(1).FlushAsync(Arg.Any<JaegerProcess>(), Arg.Any<CancellationToken>());
+        }
+    }
+}
+

--- a/test/Jaeger.Transport.Thrift.Tests/Transport/JaegerUdpTransportTests.cs
+++ b/test/Jaeger.Transport.Thrift.Tests/Transport/JaegerUdpTransportTests.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Jaeger.Core;
+using Jaeger.Thrift;
+using Jaeger.Thrift.Agent;
+using Jaeger.Transport.Thrift.Serialization;
+using Jaeger.Transport.Thrift.Transport;
+using Jaeger.Transport.Thrift.Transport.Internal;
+using Jaeger.Transport.Thrift.Transport.Sender;
+using NSubstitute;
+using Thrift.Protocols;
+using Xunit;
+using JaegerProcess = Jaeger.Thrift.Process;
+using JaegerSpan = Jaeger.Thrift.Span;
+using JaegerTag = Jaeger.Thrift.Tag;
+using JaegerBatch = Jaeger.Thrift.Batch;
+
+namespace Jaeger.Transport.Thrift.Tests.Transport
+{
+    public class JaegerUdpTransportTests
+    {
+        private readonly ISerialization _mockJaegerThriftSerialization;
+        private readonly ITProtocolFactory _protocolFactory;
+        private readonly ISender _mockSender;
+        
+        private readonly int _jSpanSize;
+        private readonly int _jProcessSize;
+        //private readonly JaegerThriftTransport _testingTransport;
+
+        public JaegerUdpTransportTests()
+        {
+            _mockJaegerThriftSerialization = Substitute.For<ISerialization>();
+            _protocolFactory = new TCompactProtocol.Factory();
+            _mockSender = Substitute.For<ISender>();
+            _mockSender.ProtocolFactory.Returns(_protocolFactory);
+
+            var jSpan = new JaegerSpan(10, 11, 12, 13, "opName", 0, 1234, 1235);
+            _jSpanSize = CalcSizeOfSerializedThrift(jSpan);
+
+            var jProcess = new JaegerProcess("testing");
+            _jProcessSize = CalcSizeOfSerializedThrift(jProcess);
+
+            _mockJaegerThriftSerialization.BuildJaegerProcessThrift(Arg.Any<IJaegerCoreTracer>()).Returns(jProcess);
+            _mockJaegerThriftSerialization.BuildJaegerThriftSpan(Arg.Any<IJaegerCoreSpan>()).Returns(jSpan);
+        }
+
+        private static int CalcSizeOfSerializedThrift(TBase thriftBase)
+        {
+            var thriftBuffer = new TMemoryBuffer();
+            var protocolFactory = new TCompactProtocol.Factory();
+            var thriftProtocol = protocolFactory.GetProtocol(thriftBuffer);
+            try
+            {
+                thriftBase.WriteAsync(thriftProtocol, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                throw new Exception("failed to calculate the size of a serialized thrift object", e);
+            }
+            return thriftBuffer.GetBuffer().Length;
+        }
+
+        private JaegerUdpTransport NewUdpTransportWithMaxPacketSize(int maxPacketSize)
+        {
+            return new JaegerUdpTransport(maxPacketSize, _mockSender, _mockJaegerThriftSerialization);
+        }
+
+        [Fact]
+        public async void EmitBatchOverhead_ShouldNotGoOverOverheadConstant()
+        {
+            var transport = new TMemoryBuffer();
+            var protocolFactory = new TCompactProtocol.Factory();
+            var client = new Agent.Client(protocolFactory.GetProtocol(transport));
+
+            var jSpan = new JaegerSpan(10, 11, 12, 13, "opName", 0, 1234, 1235);
+            var jSpanSize = CalcSizeOfSerializedThrift(jSpan);
+
+            var tests = new[] {1, 2, 14, 15, 377, 500, 65000, 0xFFFF};
+
+            foreach (var test in tests)
+            {
+                transport.Reset();
+                var batch = new List<JaegerSpan>();
+                var processTags = new List<JaegerTag>();
+                for (var j = 0; j < test; j++)
+                {
+                    batch.Add(jSpan);
+                    processTags.Add(new JaegerTag("testingTag", TagType.BINARY) { VBinary = new byte[] { 0x20 }});
+                }
+
+                var jProcess = new JaegerProcess("testing") {Tags = processTags};
+                await client.emitBatchAsync(new JaegerBatch(jProcess, batch), CancellationToken.None);
+                var jProcessSize = CalcSizeOfSerializedThrift(jProcess);
+
+                var overhead = transport.GetBuffer().Length - test * jSpanSize - jProcessSize;
+                Assert.True(overhead <= TransportConstants.UdpEmitBatchOverhead);
+            }
+        }
+
+        [Fact]
+        public async void AppendAsync_ShouldThrowWhenSpanIsTooLarge()
+        {
+            var testingTransport = NewUdpTransportWithMaxPacketSize(_jSpanSize);
+
+            var ex = await Assert.ThrowsAsync<Exception>(() => testingTransport.AppendAsync(Substitute.For<IJaegerCoreSpan>(), CancellationToken.None));
+
+            Assert.Equal("Span too large to send over UDP", ex.Message);
+        }
+
+
+        [Fact]
+        public async void AppendAsync_ShouldAddSpanToSenderAndFlushWhenItFitsJustRight()
+        {
+            var maxPacketSize = _jSpanSize + _jProcessSize + TransportConstants.UdpEmitBatchOverhead;
+            var testingTransport = NewUdpTransportWithMaxPacketSize(maxPacketSize);
+            _mockSender.FlushAsync(Arg.Any<JaegerProcess>(), Arg.Any<CancellationToken>()).Returns(1);
+
+            var sent = await testingTransport.AppendAsync(Substitute.For<IJaegerCoreSpan>(), CancellationToken.None);
+
+            Assert.Equal(1, sent);
+            _mockSender.Received(1).BufferItem(Arg.Any<JaegerSpan>());
+            await _mockSender.Received(1).FlushAsync(Arg.Any<JaegerProcess>(), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async void AppendAsync_ShouldAddSpanToSenderAndReturnWhenThereIsMoreRoom()
+        {
+            var maxPacketSize = _jSpanSize + _jProcessSize + TransportConstants.UdpEmitBatchOverhead + 1;
+            var testingTransport = NewUdpTransportWithMaxPacketSize(maxPacketSize);
+
+            var sent = await testingTransport.AppendAsync(Substitute.For<IJaegerCoreSpan>(), CancellationToken.None);
+
+            Assert.Equal(0, sent);
+            _mockSender.Received(1).BufferItem(Arg.Any<JaegerSpan>());
+            await _mockSender.Received(0).FlushAsync(Arg.Any<JaegerProcess>(), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async void AppendAsync_ShouldFlushAndThenAddSpanWhenItDoesNotFit()
+        {
+            var maxPacketSize = _jSpanSize + _jProcessSize + TransportConstants.UdpEmitBatchOverhead + 1;
+            var testingTransport = NewUdpTransportWithMaxPacketSize(maxPacketSize);
+
+            _mockSender.FlushAsync(Arg.Any<JaegerProcess>(), Arg.Any<CancellationToken>()).Returns(1);
+
+            // send the first time - we should just buffer the item
+            var sent = await testingTransport.AppendAsync(Substitute.For<IJaegerCoreSpan>(), CancellationToken.None);
+
+            Assert.Equal(0, sent);
+            _mockSender.Received(1).BufferItem(Arg.Any<JaegerSpan>());
+            await _mockSender.Received(0).FlushAsync(Arg.Any<JaegerProcess>(), Arg.Any<CancellationToken>());
+
+            // send the second time - we should flush and then buffer again
+            sent = await testingTransport.AppendAsync(Substitute.For<IJaegerCoreSpan>(), CancellationToken.None);
+
+            Assert.Equal(1, sent);
+            _mockSender.Received(2).BufferItem(Arg.Any<JaegerSpan>());
+            await _mockSender.Received(1).FlushAsync(Arg.Any<JaegerProcess>(), Arg.Any<CancellationToken>());
+        }
+    }
+}
+


### PR DESCRIPTION
This is for #46. We were not correctly checking UDP size and thus we could end up sending UDP packets that were too big. I broke out the buffering logic so that in the UDP transport we buffer items until we can't fit any more in a UDP packet. In the HTTP transport we buffer items until we reach the batch size.