### PR TITLE
Set trace id via SpanBuilder

### DIFF
--- a/src/Jaeger.Core/SpanBuilder.cs
+++ b/src/Jaeger.Core/SpanBuilder.cs
@@ -14,6 +14,7 @@ namespace Jaeger.Core
         private DateTime? _startTimestampUtc;
         private List<Reference> _references;
         private bool _ignoreActiveSpan;
+        private TraceId? _traceId;
 
         internal SpanBuilder(Tracer tracer, string operationName)
         {
@@ -82,6 +83,12 @@ namespace Jaeger.Core
             return this;
         }
 
+        public ISpanBuilder WithTraceId(TraceId traceId)
+        {
+            _traceId = traceId;
+            return this;
+        }
+
         public ISpanBuilder IgnoreActiveSpan()
         {
             _ignoreActiveSpan = true;
@@ -135,7 +142,7 @@ namespace Jaeger.Core
 
         private SpanContext CreateNewContext(string debugId)
         {
-            TraceId traceId = TraceId.NewUniqueId();
+            TraceId traceId = _traceId ?? TraceId.NewUniqueId();
             SpanId spanId = new SpanId(traceId);
 
             var flags = SpanContextFlags.None;

--- a/test/Jaeger.Core.Tests/SpanBuilderTests.cs
+++ b/test/Jaeger.Core.Tests/SpanBuilderTests.cs
@@ -129,6 +129,21 @@ namespace Jaeger.Core.Tests
         }
 
         [Fact]
+        public void SpanBuilder_WithTraceId_ShouldSetTraceId()
+        {
+            var tracer = GetTracer();
+            var providedTraceId = new TraceId(42, 33);
+
+            var builder = (SpanBuilder)tracer.BuildSpan("foo");
+            var span = (Span)builder
+                .WithTraceId(providedTraceId)
+                .Start();
+
+            var usedTraceId = span.Context.TraceId;
+            Assert.Equal(providedTraceId, usedTraceId);
+        }
+
+        [Fact]
         public void SpanBuilder_AsChildOf_IgnoresNullSpan()
         {
             var tracer = GetTracer();


### PR DESCRIPTION
Hello,

we have a system built on Kubernetes and [Linkerd ](https://linkerd.io/) and we need to somehow merge tracing logs inside the Jaeger from an infrastructure layer and from an application layer. 

Linkerd already sends trace id in an HTTP header, so it would be great to have the possibility to override trace id while building Span on the application layer. 
Is the provided solution convenient?  