### PR TITLE
Update to OpenTracing 0.12.0

### DIFF
--- a/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
+++ b/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
@@ -5,12 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
-    <PackageReference Include="OpenTracing" Version="0.11.0" />
     <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.2.0" />
   </ItemGroup>
 

--- a/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
+++ b/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
-    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.2.0" />
+    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jaeger/Jaeger.csproj
+++ b/src/Jaeger/Jaeger.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="OpenTracing" Version="0.12.0-rc1" />
+    <PackageReference Include="OpenTracing" Version="0.12.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Jaeger/Jaeger.csproj
+++ b/src/Jaeger/Jaeger.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="OpenTracing" Version="0.11.0" />
+    <PackageReference Include="OpenTracing" Version="0.12.0-rc1" />
   </ItemGroup>
 
 </Project>

--- a/src/Jaeger/LogData.cs
+++ b/src/Jaeger/LogData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Jaeger
 {
@@ -7,7 +8,7 @@ namespace Jaeger
     {
         public DateTime TimestampUtc { get; }
         public string Message { get; }
-        public IDictionary<string, object> Fields { get; }
+        public IEnumerable<KeyValuePair<string, object>> Fields { get; }
 
         public LogData(DateTime timestampUtc, string message)
         {
@@ -15,10 +16,18 @@ namespace Jaeger
             Message = message;
         }
 
-        public LogData(DateTime timestampUtc, IDictionary<string, object> fields)
+        public LogData(DateTime timestampUtc, IEnumerable<KeyValuePair<string, object>> fields)
         {
             TimestampUtc = timestampUtc;
             Fields = fields;
+        }
+
+        // for testing
+        internal object GetFieldValue(string key)
+        {
+            // We don't know for sure that we have a dictionary
+            // so we have to do the "last wins" logic ourselves.
+            return Fields?.LastOrDefault(x => x.Key == key).Value;
         }
     }
 }

--- a/src/Jaeger/SpanBuilder.cs
+++ b/src/Jaeger/SpanBuilder.cs
@@ -76,6 +76,30 @@ namespace Jaeger
             return this;
         }
 
+        public ISpanBuilder WithTag(BooleanTag tag, bool value)
+        {
+            _tags[tag.Key] = value;
+            return this;
+        }
+
+        public ISpanBuilder WithTag(IntOrStringTag tag, string value)
+        {
+            _tags[tag.Key] = value;
+            return this;
+        }
+
+        public ISpanBuilder WithTag(IntTag tag, int value)
+        {
+            _tags[tag.Key] = value;
+            return this;
+        }
+
+        public ISpanBuilder WithTag(StringTag tag, string value)
+        {
+            _tags[tag.Key] = value;
+            return this;
+        }
+
         public ISpanBuilder WithStartTimestamp(DateTimeOffset startTimestamp)
         {
             _startTimestampUtc = startTimestamp.UtcDateTime;
@@ -86,6 +110,11 @@ namespace Jaeger
         {
             _ignoreActiveSpan = true;
             return this;
+        }
+
+        public IScope StartActive()
+        {
+            return StartActive(finishSpanOnDispose: true);
         }
 
         public IScope StartActive(bool finishSpanOnDispose)

--- a/src/Jaeger/SpanContext.cs
+++ b/src/Jaeger/SpanContext.cs
@@ -10,6 +10,9 @@ namespace Jaeger
     {
         internal static readonly IReadOnlyDictionary<string, string> EmptyBaggage = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
 
+        private string _cachedTraceIdToString;
+        private string _cachedSpanIdToString;
+
         public TraceId TraceId { get; }
         public SpanId SpanId { get; }
         public SpanId ParentId { get; }
@@ -20,6 +23,32 @@ namespace Jaeger
         public bool IsSampled => Flags.HasFlag(SpanContextFlags.Sampled);
 
         public bool IsDebug => Flags.HasFlag(SpanContextFlags.Debug);
+
+        string ISpanContext.TraceId
+        {
+            get
+            {
+                if (_cachedTraceIdToString == null)
+                {
+                    _cachedTraceIdToString = TraceId.ToString();
+                }
+
+                return _cachedTraceIdToString;
+            }
+        }
+
+        string ISpanContext.SpanId
+        {
+            get
+            {
+                if (_cachedSpanIdToString == null)
+                {
+                    _cachedSpanIdToString = SpanId.ToString();
+                }
+
+                return _cachedSpanIdToString;
+            }
+        }
 
         public SpanContext(TraceId traceId, SpanId spanId, SpanId parentId, SpanContextFlags flags)
             : this(traceId, spanId, parentId, flags, EmptyBaggage, debugId: null)

--- a/test/Jaeger.Tests/Baggage/BaggageSetterTests.cs
+++ b/test/Jaeger.Tests/Baggage/BaggageSetterTests.cs
@@ -140,21 +140,21 @@ namespace Jaeger.Tests.Baggage
         {
             var logs = span.GetLogs();
             Assert.NotEmpty(logs);
-            IDictionary<string, object> fields = logs[logs.Count - 1].Fields;
-            Assert.Equal("baggage", fields["event"]);
-            Assert.Equal(key, fields["key"]);
-            Assert.Equal(value, fields["value"]);
+            LogData log = logs[logs.Count - 1];
+            Assert.Equal("baggage", log.GetFieldValue("event"));
+            Assert.Equal(key, log.GetFieldValue("key"));
+            Assert.Equal(value, log.GetFieldValue("value"));
             if (truncate)
             {
-                Assert.True((bool)fields["truncated"]);
+                Assert.True((bool)log.GetFieldValue("truncated"));
             }
             if (@override)
             {
-                Assert.True((bool)fields["override"]);
+                Assert.True((bool)log.GetFieldValue("override"));
             }
             if (invalid)
             {
-                Assert.True((bool)fields["invalid"]);
+                Assert.True((bool)log.GetFieldValue("invalid"));
             }
         }
     }

--- a/test/Jaeger.Tests/Baggage/BaggageSetterTests.cs
+++ b/test/Jaeger.Tests/Baggage/BaggageSetterTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Jaeger.Baggage;
 using Jaeger.Metrics;
 using Jaeger.Reporters;

--- a/test/Jaeger.Tests/Jaeger.Tests.csproj
+++ b/test/Jaeger.Tests/Jaeger.Tests.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="OpenTracing" Version="0.11.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/Jaeger.Tests/SpanTests.cs
+++ b/test/Jaeger.Tests/SpanTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Jaeger.Baggage;
 using Jaeger.Metrics;
 using Jaeger.Reporters;
@@ -316,12 +317,12 @@ namespace Jaeger.Tests
 
             var logData = span.GetLogs();
             Assert.Single(logData);
-            Assert.Equal(4, logData[0].Fields.Count);
+            Assert.Equal(4, logData[0].Fields.Count());
 
-            Assert.Equal(ex, logData[0].Fields[LogFields.ErrorObject]);
-            Assert.Equal(ex.Message, logData[0].Fields[LogFields.Message]);
-            Assert.Equal(ex.GetType().FullName, logData[0].Fields[LogFields.ErrorKind]);
-            Assert.Equal(ex.StackTrace, logData[0].Fields[LogFields.Stack]);
+            Assert.Equal(ex, logData[0].GetFieldValue(LogFields.ErrorObject));
+            Assert.Equal(ex.Message, logData[0].GetFieldValue(LogFields.Message));
+            Assert.Equal(ex.GetType().FullName, logData[0].GetFieldValue(LogFields.ErrorKind));
+            Assert.Equal(ex.StackTrace, logData[0].GetFieldValue(LogFields.Stack));
         }
 
         [Fact]
@@ -338,12 +339,12 @@ namespace Jaeger.Tests
 
             var logData = span.GetLogs();
             Assert.Single(logData);
-            Assert.Equal(4, logData[0].Fields.Count);
+            Assert.Equal(4, logData[0].Fields.Count());
 
-            Assert.Equal(ex, logData[0].Fields[LogFields.ErrorObject]);
-            Assert.Equal(ex.Message, logData[0].Fields[LogFields.Message]);
-            Assert.Equal(ex.GetType().FullName, logData[0].Fields[LogFields.ErrorKind]);
-            Assert.Equal(ex.StackTrace, logData[0].Fields[LogFields.Stack]);
+            Assert.Equal(ex, logData[0].GetFieldValue(LogFields.ErrorObject));
+            Assert.Equal(ex.Message, logData[0].GetFieldValue(LogFields.Message));
+            Assert.Equal(ex.GetType().FullName, logData[0].GetFieldValue(LogFields.ErrorKind));
+            Assert.Equal(ex.StackTrace, logData[0].GetFieldValue(LogFields.Stack));
         }
 
         [Fact]
@@ -359,7 +360,7 @@ namespace Jaeger.Tests
             var logData = span.GetLogs();
             Assert.Single(logData);
             Assert.Single(logData[0].Fields);
-            Assert.Equal(obj, logData[0].Fields[LogFields.ErrorObject]);
+            Assert.Equal(obj, logData[0].GetFieldValue(LogFields.ErrorObject));
         }
 
         [Fact]
@@ -380,7 +381,7 @@ namespace Jaeger.Tests
             var logData = span.GetLogs();
             Assert.Single(logData);
             Assert.Single(logData[0].Fields);
-            Assert.Equal(ex, logData[0].Fields[LogFields.ErrorObject]);
+            Assert.Equal(ex, logData[0].GetFieldValue(LogFields.ErrorObject));
         }
 
         [Fact]


### PR DESCRIPTION
This currently targets OpenTracing v0.12.0-rc1. I'll update this PR as soon as the final version is released.

The example currently throws a runtime exception because there's no compatible release of OpenTracing.Contrib.NetCore yet but I also already have an open PR for that.