### PR TITLE
Removed OpenTracing version from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # C# Client for Jaeger (https://jaegertracing.io)
 
-- Implements C# [OpenTracing API](https://github.com/opentracing/opentracing-csharp) v. 0.12
+- Implements C# [OpenTracing API](https://github.com/opentracing/opentracing-csharp)
 - Supports netstandard 2.0
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # C# Client for Jaeger (https://jaegertracing.io)
 
-- Implements C# [OpenTracing API](https://github.com/opentracing/opentracing-csharp) v. 0.11
+- Implements C# [OpenTracing API](https://github.com/opentracing/opentracing-csharp) v. 0.12
 - Supports netstandard 2.0
 
 ## Status


### PR DESCRIPTION
Just saw that we missed to update the OpenTracing version in the readme. Maybe we should just remove the version?