### PR TITLE
Update Newtonsoft.Json to 11.0.2

### DIFF
--- a/src/Jaeger/Jaeger.csproj
+++ b/src/Jaeger/Jaeger.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="OpenTracing" Version="0.12.0" />
   </ItemGroup>
 


### PR DESCRIPTION
`Newtonsoft.Json` version 10.0.3 has no target for `.NETStandard,Version=v2.0` and therefore uses `.NETStandard,Version=v1.3` which adds a whole list of dependencies. Starting with version 11, no dependencies are needed.