### PR TITLE
Ported ToString() methods from java

### DIFF
--- a/src/Jaeger.Thrift/Senders/Internal/ThriftUdpClientTransport.cs
+++ b/src/Jaeger.Thrift/Senders/Internal/ThriftUdpClientTransport.cs
@@ -105,5 +105,10 @@ namespace Jaeger.Thrift.Senders.Internal
             }
             _isDisposed = true;
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(ThriftUdpClientTransport)}(Client={_client.Client.RemoteEndPoint})";
+        }
     }
 }

--- a/src/Jaeger/Reporters/CompositeReporter.cs
+++ b/src/Jaeger/Reporters/CompositeReporter.cs
@@ -28,5 +28,10 @@ namespace Jaeger.Reporters
                 await reporter.CloseAsync(cancellationToken).ConfigureAwait(false);
             }
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(CompositeReporter)}(Reporters={string.Join(", ", _reporters)})";
+        }
     }
 }

--- a/src/Jaeger/Reporters/InMemoryReporter.cs
+++ b/src/Jaeger/Reporters/InMemoryReporter.cs
@@ -37,5 +37,13 @@ namespace Jaeger.Reporters
         {
             return Task.CompletedTask;
         }
+
+        public override string ToString()
+        {
+            lock (_lock)
+            {
+                return $"{nameof(InMemoryReporter)}(Spans={string.Join(", ", _spans)})";
+            }
+        }
     }
 }

--- a/src/Jaeger/Reporters/LoggingReporter.cs
+++ b/src/Jaeger/Reporters/LoggingReporter.cs
@@ -26,5 +26,10 @@ namespace Jaeger.Reporters
         {
             return Task.CompletedTask;
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(LoggingReporter)}(Logger={Logger})";
+        }
     }
 }

--- a/src/Jaeger/Reporters/NoopReporter.cs
+++ b/src/Jaeger/Reporters/NoopReporter.cs
@@ -13,5 +13,10 @@ namespace Jaeger.Reporters
         {
             return Task.CompletedTask;
         }
+
+        public override string ToString()
+        {
+            return nameof(NoopReporter);
+        }
     }
 }

--- a/src/Jaeger/Reporters/RemoteReporter.cs
+++ b/src/Jaeger/Reporters/RemoteReporter.cs
@@ -144,6 +144,11 @@ namespace Jaeger.Reporters
             }
         }
 
+        public override string ToString()
+        {
+            return $"{nameof(RemoteReporter)}(Sender={_sender})";
+        }
+
         /*
          * The code below implements the command pattern. This pattern is useful for
          * situations where multiple threads would need to synchronize on a resource,

--- a/src/Jaeger/Samplers/GuaranteedThroughputSampler.cs
+++ b/src/Jaeger/Samplers/GuaranteedThroughputSampler.cs
@@ -94,7 +94,8 @@ namespace Jaeger.Samplers
         {
             lock (_lock)
             {
-                return $"{nameof(GuaranteedThroughputSampler)}({_probabilisticSampler}/{_lowerBoundSampler})";
+                return $"{nameof(GuaranteedThroughputSampler)}(ProbabilisticSampler={_probabilisticSampler}, " 
+                       + $"LowerBoundSampler={_lowerBoundSampler}, Tags={string.Join(", ", _tags)})";
             }
         }
 

--- a/src/Jaeger/Samplers/HttpSamplingManager.cs
+++ b/src/Jaeger/Samplers/HttpSamplingManager.cs
@@ -36,5 +36,10 @@ namespace Jaeger.Samplers
 
             return ParseJson(jsonString);
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(HttpSamplingManager)}(HostPort={_hostPort})";
+        }
     }
 }

--- a/src/Jaeger/Samplers/PerOperationSampler.cs
+++ b/src/Jaeger/Samplers/PerOperationSampler.cs
@@ -117,7 +117,7 @@ namespace Jaeger.Samplers
         {
             lock (_lock)
             {
-                return $"{nameof(PerOperationSampler)}({LowerBound}/{MaxOperations})";
+                return $"{nameof(PerOperationSampler)}(LowerBound={LowerBound}, MaxOperations={MaxOperations})";
             }
         }
 

--- a/src/Jaeger/Samplers/ProbabilisticSampler.cs
+++ b/src/Jaeger/Samplers/ProbabilisticSampler.cs
@@ -52,7 +52,8 @@ namespace Jaeger.Samplers
 
         public override string ToString()
         {
-            return $"{nameof(ProbabilisticSampler)}({SamplingRate})";
+            return $"{nameof(ProbabilisticSampler)}(PositiveSamplingBoundary={_positiveSamplingBoundary}, " 
+                   + $"NegativeSamplingBoundary={_negativeSamplingBoundary}, SamplingRate={SamplingRate})";
         }
 
         public void Close()

--- a/src/Jaeger/Samplers/RateLimitingSampler.cs
+++ b/src/Jaeger/Samplers/RateLimitingSampler.cs
@@ -37,7 +37,7 @@ namespace Jaeger.Samplers
 
         public override string ToString()
         {
-            return $"{nameof(RateLimitingSampler)}({MaxTracesPerSecond})";
+            return $"{nameof(RateLimitingSampler)}(MaxTracesPerSecond={MaxTracesPerSecond}, Tags={string.Join(", ", _tags)})";
         }
 
         public void Close()

--- a/src/Jaeger/Samplers/RemoteControlledSampler.cs
+++ b/src/Jaeger/Samplers/RemoteControlledSampler.cs
@@ -132,7 +132,7 @@ namespace Jaeger.Samplers
         {
             lock (_lock)
             {
-                return $"{nameof(RemoteControlledSampler)}({Sampler})";
+                return $"{nameof(RemoteControlledSampler)}(Sampler={Sampler})";
             }
         }
 

--- a/src/Jaeger/Senders/HttpSender.cs
+++ b/src/Jaeger/Senders/HttpSender.cs
@@ -73,6 +73,11 @@ namespace Jaeger.Senders
             }
         }
 
+        public override string ToString()
+        {
+            return $"{nameof(HttpSender)}";
+        }
+
         public sealed class Builder
         {
             internal string Endpoint { get; }

--- a/src/Jaeger/Senders/ThriftSender.cs
+++ b/src/Jaeger/Senders/ThriftSender.cs
@@ -125,5 +125,10 @@ namespace Jaeger.Senders
         {
             return FlushAsync(cancellationToken);
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(ThriftSender)}(ProcessBytesSize={_processBytesSize}, ByteBufferSize={_byteBufferSize})";
+        }
     }
 }

--- a/src/Jaeger/Senders/UdpSender.cs
+++ b/src/Jaeger/Senders/UdpSender.cs
@@ -79,5 +79,10 @@ namespace Jaeger.Senders
                 _udpTransport.Close();
             }
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(UdpSender)}(UdpTransport={_udpTransport})";
+        }
     }
 }

--- a/src/Jaeger/Tracer.cs
+++ b/src/Jaeger/Tracer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Jaeger.Baggage;
@@ -106,6 +107,23 @@ namespace Jaeger
             }
 
             Tags = tags;
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append(nameof(Tracer));
+            sb.Append('(');
+            sb.Append($"ServiceName={ServiceName}, ");
+            sb.Append($"Version={Version}, ");
+            sb.Append($"Reporter={Reporter}, ");
+            sb.Append($"Sampler={Sampler}, ");
+            sb.Append($"IPv4={IPv4}, ");
+            sb.Append($"Tags={string.Join(", ", Tags)}, ");
+            sb.Append($"ZipkinSharedRpcSpan={ZipkinSharedRpcSpan}, ");
+            sb.Append($"ExpandExceptionLogs={ExpandExceptionLogs}");
+            sb.Append(')');
+            return sb.ToString();
         }
 
         public void ReportSpan(Span span)


### PR DESCRIPTION
The [Configuration.GetTracer()](https://github.com/jaegertracing/jaeger-client-java/blob/3ffaf9d753fe96a1925729d42fd371a0a166c03b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java#L215) method is getting a printable representation of the Tracer and all it's referenced classes. The java implementation uses `lombok.ToString` annotation for this ([see Tracer](https://github.com/jaegertracing/jaeger-client-java/blob/3ffaf9d753fe96a1925729d42fd371a0a166c03b/jaeger-core/src/main/java/io/jaegertracing/Tracer.java#L57)). In C# we have to implement the `ToString()` methods ourselves.

This highly improves readability of the debug log. Right now, it only says `Initialized Jaeger.Tracer` for each of my tracers. I would have wanted to have at least the `ServiceName` printed.