### PR TITLE
Added Configuration.WithExpandExceptionLogs

### DIFF
--- a/src/Jaeger/Configuration.cs
+++ b/src/Jaeger/Configuration.cs
@@ -102,6 +102,11 @@ namespace Jaeger
         public const string JaegerTraceId128Bit = JaegerPrefix + "TRACEID_128BIT";
 
         /// <summary>
+        /// Whether the tracer should expand exception logs.
+        /// </summary>
+        public const string JaegerExpandExceptionLogs = JaegerPrefix + "EXPAND_EXCEPTION_LOGS";
+
+        /// <summary>
         /// Comma separated list of formats to use for propagating the trace context. Default will the
         /// standard Jaeger format. Valid values are jaeger and b3.
         /// </summary>
@@ -135,6 +140,7 @@ namespace Jaeger
         private IMetricsFactory _metricsFactory;
         private Dictionary<string, string> _tracerTags;
         private bool _useTraceId128Bit;
+        private bool _expandExceptionLogs;
 
         /// <summary>
         /// Lazy singleton <see cref="Tracer"/> initialized in <see cref="GetTracer()"/> method.
@@ -161,6 +167,7 @@ namespace Jaeger
             return new Configuration(GetProperty(JaegerServiceName), loggerFactory)
                 .WithTracerTags(TracerTagsFromEnv(logger))
                 .WithTraceId128Bit(GetPropertyAsBool(JaegerTraceId128Bit, logger).GetValueOrDefault(false))
+                .WithExpandExceptionLogs(GetPropertyAsBool(JaegerExpandExceptionLogs, logger).GetValueOrDefault(false))
                 .WithReporter(ReporterConfiguration.FromEnv(loggerFactory))
                 .WithSampler(SamplerConfiguration.FromEnv(loggerFactory))
                 .WithCodec(CodecConfiguration.FromEnv(loggerFactory));
@@ -198,6 +205,11 @@ namespace Jaeger
             {
                 builder = builder.WithTraceId128Bit();
             }
+
+            if (_expandExceptionLogs)
+			{
+				builder = builder.WithExpandExceptionLogs();
+			}
 
             _codecConfig.Apply(builder);
 
@@ -269,6 +281,12 @@ namespace Jaeger
             {
                 _tracerTags = new Dictionary<string, string>(tracerTags);
             }
+            return this;
+        }
+
+        public Configuration WithExpandExceptionLogs(bool expandExceptionLogs=true)
+        {
+            _expandExceptionLogs = expandExceptionLogs;
             return this;
         }
 

--- a/test/Jaeger.Tests/ConfigurationTests.cs
+++ b/test/Jaeger.Tests/ConfigurationTests.cs
@@ -51,6 +51,7 @@ namespace Jaeger.Tests
             ClearProperty(Configuration.JaegerServiceName);
             ClearProperty(Configuration.JaegerTags);
             ClearProperty(Configuration.JaegerTraceId128Bit);
+            ClearProperty(Configuration.JaegerExpandExceptionLogs);
             ClearProperty(Configuration.JaegerEndpoint);
             ClearProperty(Configuration.JaegerAuthToken);
             ClearProperty(Configuration.JaegerUser);
@@ -188,6 +189,24 @@ namespace Jaeger.Tests
             SetProperty(Configuration.JaegerTags, "testTag1=${" + TestProperty + ":hello}");
             Tracer tracer = (Tracer)Configuration.FromEnv(_loggerFactory).GetTracer();
             Assert.Equal("goodbye", tracer.Tags["testTag1"]);
+        }
+
+        [Fact]
+        public void TestTracerExpandExceptionLogs()
+        {
+            SetProperty(Configuration.JaegerServiceName, "Test");
+            SetProperty(Configuration.JaegerExpandExceptionLogs, "true");
+            Tracer tracer = (Tracer)Configuration.FromEnv(_loggerFactory).GetTracer();
+            Assert.True(tracer.ExpandExceptionLogs);
+        }
+
+        [Fact]
+        public void TestTracerInvalidExpandExceptionLogs()
+        {
+            SetProperty(Configuration.JaegerServiceName, "Test");
+            SetProperty(Configuration.JaegerExpandExceptionLogs, "X");
+            Tracer tracer = (Tracer)Configuration.FromEnv(_loggerFactory).GetTracer();
+            Assert.False(tracer.ExpandExceptionLogs);
         }
 
         [Fact]


### PR DESCRIPTION
Right now, when using `Configuration`, it's not possible to call `WithExpandExceptionLogs()` on the `TraceBuilder` without using `GetTracerBuilder()` and Build it directly instead of using `GetTracer()`. It seems, that this is nearly the only flag that can not be set by environment.

I assume this should be discussed and proposed in the meta repo? But I first wanted to hear if @cwe1ss or @yurishkuro already have an opionion on that.