### PR TITLE
Only use 64bit TraceID for compatability

### DIFF
--- a/src/Jaeger/TraceId.cs
+++ b/src/Jaeger/TraceId.cs
@@ -15,7 +15,8 @@ namespace Jaeger
 
         public static TraceId NewUniqueId()
         {
-            return new TraceId(Utils.UniqueId(), Utils.UniqueId());
+            // TODO: Only using 64bit for compatability. Make it configurable to use 128bit TraceIds.
+            return new TraceId(Utils.UniqueId());
         }
 
         public TraceId(long low) : this(0, low)


### PR DESCRIPTION
Fixes #81 

I added a TODO remark for later fix. I think, the cleanest option would be to have it in `Configuration`. But this would make our `Configuration` and `Tracer` implementations differ from `Java`.