### PR TITLE
Synchronizing access to static Random instance

### DIFF
--- a/src/Jaeger/Util/Utils.cs
+++ b/src/Jaeger/Util/Utils.cs
@@ -43,7 +43,10 @@ namespace Jaeger.Util
             while (value == 0)
             {
                 var bytes = new byte[8];
-                Random.NextBytes(bytes);
+                lock (Random)
+                {
+                    Random.NextBytes(bytes);
+                }
                 value = BitConverter.ToInt64(bytes, 0);
             }
             return value;


### PR DESCRIPTION
System.Random instance methods are not thread safe. Concurrent requests can result in the Random instance returning 0 for all future requests. Paired with the current implementation of 'while (value == 0)' results in an infinite loop for each new span/trace that will end up saturating CPU.

This update is the least invasive change to prevent the above issue. While theoretically the performance could be limited by the serialized access to this single Random instance, it is almost assured that any work being done inside the created Span is many orders of magnitude greater than the single call to Random.

The Random instance is private to the Utils class so it is safe to lock on.

Running the benchmarks locally, Span building added between 50 to 17 ns to span creation. DateTime and Tag benchmarks were essentially unchanged within the reported error thresholds.

Reference for System.Random returning zero: http://csharpindepth.com/Articles/Chapter12/Random.aspx

Signed-off-by: Ryan Karg <rwkarg@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Issue #92 

## Short description of the changes
- Synchronize access to static System.Random instance
