### PR TITLE
Added 128bit trace id configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ JAEGER_SAMPLER_TYPE | no | The sampler type
 JAEGER_SAMPLER_PARAM | no | The sampler parameter (number)
 JAEGER_SAMPLER_MANAGER_HOST_PORT | no | The host name and port when using the remote controlled sampler
 JAEGER_TAGS | no | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found
+JAEGER_TRACEID_128BIT | no | Whether to use 128bit TraceID instead of 64bit
 
 Setting `JAEGER_AGENT_HOST`/`JAEGER_AGENT_PORT` will make the client send traces to the agent via `UdpSender`.
 If the `JAEGER_ENDPOINT` environment variable is also set, the traces are sent to the endpoint, effectively making

--- a/src/Jaeger/Configuration.cs
+++ b/src/Jaeger/Configuration.cs
@@ -79,7 +79,7 @@ namespace Jaeger
         /// <summary>
         /// The sampler parameter (number).
         /// </summary>
-        public const string JaegerSamplerParam = "JAEGER_SAMPLER_PARAM";
+        public const string JaegerSamplerParam = JaegerPrefix + "SAMPLER_PARAM";
 
         /// <summary>
         /// The sampler manager host:port.
@@ -95,6 +95,11 @@ namespace Jaeger
         /// The tracer level tags.
         /// </summary>
         public const string JaegerTags = JaegerPrefix + "TAGS";
+
+        /// <summary>
+        /// Whether to use 128bit TraceID instead of 64bit.
+        /// </summary>
+        public const string JaegerTraceId128Bit = JaegerPrefix + "TRACEID_128BIT";
 
         /// <summary>
         /// Comma separated list of formats to use for propagating the trace context. Default will the
@@ -129,6 +134,7 @@ namespace Jaeger
         private CodecConfiguration _codecConfig;
         private IMetricsFactory _metricsFactory;
         private Dictionary<string, string> _tracerTags;
+        private bool _useTraceId128Bit;
 
         /// <summary>
         /// Lazy singleton <see cref="Tracer"/> initialized in <see cref="GetTracer()"/> method.
@@ -154,6 +160,7 @@ namespace Jaeger
 
             return new Configuration(GetProperty(JaegerServiceName), loggerFactory)
                 .WithTracerTags(TracerTagsFromEnv(logger))
+                .WithTraceId128Bit(GetPropertyAsBool(JaegerTraceId128Bit, logger).GetValueOrDefault(false))
                 .WithReporter(ReporterConfiguration.FromEnv(loggerFactory))
                 .WithSampler(SamplerConfiguration.FromEnv(loggerFactory))
                 .WithCodec(CodecConfiguration.FromEnv(loggerFactory));
@@ -186,6 +193,11 @@ namespace Jaeger
                 .WithReporter(reporter)
                 .WithMetrics(metrics)
                 .WithTags(_tracerTags);
+
+            if (_useTraceId128Bit)
+            {
+                builder = builder.WithTraceId128Bit();
+            }
 
             _codecConfig.Apply(builder);
 
@@ -242,6 +254,12 @@ namespace Jaeger
         public Configuration WithCodec(CodecConfiguration codecConfig)
         {
             _codecConfig = codecConfig;
+            return this;
+        }
+
+        private Configuration WithTraceId128Bit(bool useTraceId128Bit)
+        {
+            _useTraceId128Bit = useTraceId128Bit;
             return this;
         }
 

--- a/src/Jaeger/SpanBuilder.cs
+++ b/src/Jaeger/SpanBuilder.cs
@@ -164,7 +164,7 @@ namespace Jaeger
 
         private SpanContext CreateNewContext(string debugId)
         {
-            TraceId traceId = TraceId.NewUniqueId();
+            TraceId traceId = TraceId.NewUniqueId(_tracer.UseTraceId128Bit);
             SpanId spanId = new SpanId(traceId);
 
             var flags = SpanContextFlags.None;

--- a/src/Jaeger/TraceId.cs
+++ b/src/Jaeger/TraceId.cs
@@ -13,10 +13,11 @@ namespace Jaeger
         public long Low { get; }
         public bool IsZero => Low == 0 && High == 0;
 
-        public static TraceId NewUniqueId()
+        public static TraceId NewUniqueId(bool useHigh)
         {
-            // TODO: Only using 64bit for compatability. Make it configurable to use 128bit TraceIds.
-            return new TraceId(Utils.UniqueId());
+            var high = useHigh ? Utils.UniqueId() : 0;
+            var low = Utils.UniqueId();
+            return new TraceId(high, low);
         }
 
         public TraceId(long low) : this(0, low)

--- a/test/Jaeger.Tests/ConfigurationTests.cs
+++ b/test/Jaeger.Tests/ConfigurationTests.cs
@@ -50,6 +50,7 @@ namespace Jaeger.Tests
             ClearProperty(Configuration.JaegerSamplerManagerHostPort);
             ClearProperty(Configuration.JaegerServiceName);
             ClearProperty(Configuration.JaegerTags);
+            ClearProperty(Configuration.JaegerTraceId128Bit);
             ClearProperty(Configuration.JaegerEndpoint);
             ClearProperty(Configuration.JaegerAuthToken);
             ClearProperty(Configuration.JaegerUser);
@@ -131,6 +132,24 @@ namespace Jaeger.Tests
             SetProperty(Configuration.JaegerReporterLogSpans, "X");
             ReporterConfiguration reporterConfig = ReporterConfiguration.FromEnv(_loggerFactory);
             Assert.False(reporterConfig.LogSpans);
+        }
+
+        [Fact]
+        public void TestTracerUseTraceIdHigh()
+        {
+            SetProperty(Configuration.JaegerServiceName, "Test");
+            SetProperty(Configuration.JaegerTraceId128Bit, "1");
+            Tracer tracer = (Tracer)Configuration.FromEnv(_loggerFactory).GetTracer();
+            Assert.True(tracer.UseTraceId128Bit);
+        }
+
+        [Fact]
+        public void TestTracerInvalidUseTraceIdHigh()
+        {
+            SetProperty(Configuration.JaegerServiceName, "Test");
+            SetProperty(Configuration.JaegerTraceId128Bit, "X");
+            Tracer tracer = (Tracer)Configuration.FromEnv(_loggerFactory).GetTracer();
+            Assert.False(tracer.UseTraceId128Bit);
         }
 
         [Fact]

--- a/test/Jaeger.Tests/SpanTests.cs
+++ b/test/Jaeger.Tests/SpanTests.cs
@@ -40,6 +40,37 @@ namespace Jaeger.Tests
         }
 
         [Fact]
+        public void TestTraceId64Bit()
+        {
+            var tracer = new Tracer.Builder("name")
+                .Build();
+
+            // no exception
+            var span = tracer.BuildSpan("foo").Start();
+            span.Finish();
+
+            var spanContext = span.Context as SpanContext;
+            Assert.NotNull(spanContext);
+            Assert.True(spanContext.TraceId.High == 0);
+        }
+
+        [Fact]
+        public void TestTraceId128Bit()
+        {
+            var tracer = new Tracer.Builder("name")
+                .WithTraceId128Bit()
+                .Build();
+
+            // no exception
+            var span = tracer.BuildSpan("foo").Start();
+            span.Finish();
+
+            var spanContext = span.Context as SpanContext;
+            Assert.NotNull(spanContext);
+            Assert.True(spanContext.TraceId.High != 0);
+        }
+
+        [Fact]
         public void TestSpanMetrics()
         {
             Assert.Equal(1, metricsFactory.GetCounter("jaeger:started_spans", "sampled=y"));
@@ -51,13 +82,13 @@ namespace Jaeger.Tests
         {
             string service = "SamplerTest";
             IBaggageRestrictionManager mgr = Substitute.ForPartsOf<DefaultBaggageRestrictionManager>();
-            tracer = new Tracer.Builder(service)
+            var tracer = new Tracer.Builder(service)
                     .WithReporter(reporter)
                     .WithSampler(new ConstSampler(true))
                     .WithClock(clock)
                     .WithBaggageRestrictionManager(mgr)
                     .Build();
-            span = (Span)tracer.BuildSpan("some-operation").Start();
+            var span = (Span)tracer.BuildSpan("some-operation").Start();
 
             string key = "key";
             string value = "value";

--- a/test/Jaeger.Tests/TracerTests.cs
+++ b/test/Jaeger.Tests/TracerTests.cs
@@ -38,6 +38,25 @@ namespace Jaeger.Tests
         }
 
         [Fact]
+        public void TestTraceId64Bit()
+        {
+            var tracer = new Tracer.Builder("name")
+                .Build();
+            
+            Assert.False(tracer.UseTraceId128Bit);
+        }
+
+        [Fact]
+        public void TestTraceId128Bit()
+        {
+            var tracer = new Tracer.Builder("name")
+                .WithTraceId128Bit()
+                .Build();
+
+            Assert.True(tracer.UseTraceId128Bit);
+        }
+
+        [Fact]
         public void TestBuildSpan()
         {
             string expectedOperation = "fry";


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #83

## Short description of the changes
- Added environment variable `JAEGER_TRACEID_128BIT`
- Added `WithTraceId128Bit` method to `Configuration`
- Added `WithTraceId128Bit` method to `Tracer.Builder`
- Adde `UseTraceId128Bit` property to `Tracer`