### PR TITLE
Add Content-Type header to Http Thrift requests

### DIFF
--- a/src/Thrift/netcore/Thrift/Transports/Client/THttpClientTransport.cs
+++ b/src/Thrift/netcore/Thrift/Transports/Client/THttpClientTransport.cs
@@ -40,6 +40,8 @@ namespace Thrift.Transports.Client
 
         private bool _isDisposed;
         private MemoryStream _outputStream = new MemoryStream();
+        private static readonly MediaTypeWithQualityHeaderValue XThriftMediaType = new MediaTypeWithQualityHeaderValue("application/x-thrift");
+        private static readonly MediaTypeWithQualityHeaderValue ApacheThriftMediaType = new MediaTypeWithQualityHeaderValue("application/vnd.apache.thrift.binary");
 
         public THttpClientTransport(Uri u, IDictionary<string, string> customHeaders)
             : this(u, Enumerable.Empty<X509Certificate>(), customHeaders)
@@ -148,7 +150,7 @@ namespace Thrift.Transports.Client
                 httpClient.Timeout = TimeSpan.FromSeconds(_connectTimeout);
             }
 
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-thrift"));
+            httpClient.DefaultRequestHeaders.Accept.Add(XThriftMediaType);
             httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("THttpClientTransport", "1.0.0"));
 
             if (CustomHeaders != null)
@@ -175,6 +177,7 @@ namespace Thrift.Transports.Client
 
                     using (var outStream = new StreamContent(_outputStream))
                     {
+                        outStream.Headers.ContentType = ApacheThriftMediaType;
                         var msg = await _httpClient.PostAsync(_uri, outStream, cancellationToken);
 
                         msg.EnsureSuccessStatusCode();


### PR DESCRIPTION
The current version of the all-in-one container will reject an Http Thrift request (port 14268) if it doesn't have a `Content-Type` header.
Older versions would accept those requests without the header (I'm not sure exactly which version the change in behavior started in).

I've tested with the "old" version and it will accept spans either with or without the header.
The latest version will only accept spans with the header. Spans without the header will result in a 400 response with the message `Cannot parse content type: mime: no media type`

Signed-off-by: rwkarg <rwkarg@gmail.com>

## Which problem is this PR solving?
- Issue #99
- Http Thrift requests sent to the latest Jaeger backend are rejected if they do not specify a `Content-Type` header

## Short description of the changes
- Add the expected header
