### PR TITLE
Add client certificates only if any provided

### DIFF
--- a/src/Thrift/netcore/Thrift/Transports/Client/THttpClientTransport.cs
+++ b/src/Thrift/netcore/Thrift/Transports/Client/THttpClientTransport.cs
@@ -140,7 +140,8 @@ namespace Thrift.Transports.Client
         private HttpClient CreateClient()
         {
             var handler = new HttpClientHandler();
-            handler.ClientCertificates.AddRange(_certificates);
+            if(_certificates.Length > 0)
+                handler.ClientCertificates.AddRange(_certificates);
 
             var httpClient = new HttpClient(handler);
 

--- a/src/Thrift/netcore/Thrift/Transports/Client/THttpClientTransport.cs
+++ b/src/Thrift/netcore/Thrift/Transports/Client/THttpClientTransport.cs
@@ -140,8 +140,10 @@ namespace Thrift.Transports.Client
         private HttpClient CreateClient()
         {
             var handler = new HttpClientHandler();
-            if(_certificates.Length > 0)
+            if (_certificates.Length > 0)
+            {
                 handler.ClientCertificates.AddRange(_certificates);
+            }
 
             var httpClient = new HttpClient(handler);
 


### PR DESCRIPTION
Not all .NET Framework versions that claim to be netstandard2.0 
compliant implement methods necessary for the 
ClientCertificates property to be accessed and result in a 
MissingMethodException being thrown. 
This conditional will only attempt to access that property if 
additional client certificates are provided. 
Additionally, the only usage by HttpSender to create a 
THttpClientTransport does not ever pass in additional certificates 
so this will always skip over the property access. 
As a result, this library can be used on older .NET Frameworks that 
otherwise implement the netstandard2.0 framework.

Signed-off-by: rwkarg <rwkarg@gmail.com>

## Which problem is this PR solving?
- Resolves #105 

## Short description of the changes
- Conditionally access the ClientCertificates property only if additional client certificates are provided
