### PR TITLE
Refactor method for resolving configuration properties (#57)

### DIFF
--- a/test/Jaeger.Tests/ConfigurationTests.cs
+++ b/test/Jaeger.Tests/ConfigurationTests.cs
@@ -83,6 +83,17 @@ namespace Jaeger.Tests
         }
 
         [Fact]
+        public void TestFromEnvWithPropertyResolver()
+        {
+            var properties = new Dictionary<string, string>
+            {
+                {Configuration.JaegerServiceName, "TestFromPropertyResolver"},
+            };
+            Assert.NotNull(Configuration.FromEnv(_loggerFactory, name => properties.GetValueOrDefault(name)).GetTracer());
+            Assert.False(GlobalTracer.IsRegistered());
+        }
+
+        [Fact]
         public void TestSamplerConst()
         {
             SetProperty(Configuration.JaegerSamplerType, ConstSampler.Type);


### PR DESCRIPTION
_I welcome feedback on this work. Thanks for your time in reviewing!_

## Which problem is this PR solving?
- #57 

## Short description of the changes

Updated the method signatures that build configuration `FromEnv` to take an optional PropertyResolver delegate that can be used to override the default behavior of resolving properties from environment variables.

This is intended to be an alternative solution to directly depending on Microsoft.Extensions.Configuration or similar sources of configuration data.
