### PR TITLE
Add commented-out Jaeger PackageReference

### DIFF
--- a/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
+++ b/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
@@ -7,6 +7,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
     <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.4.0" />
+
+    <!-- NOTE:
+        In case you're building this application standalone, use below PackageReference 
+        with appropriate an appropriate version instead of relative-path ProjectReference 
+        to Jaeger project -->
+    <!-- PackageReference Include="Jaeger" Version="0.2.1" /-->
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
+++ b/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
@@ -10,7 +10,7 @@
 
     <!-- NOTE:
         In case you're building this application standalone, use below PackageReference 
-        with appropriate an appropriate version instead of relative-path ProjectReference 
+        with an appropriate version instead of relative-path ProjectReference 
         to Jaeger project -->
     <!-- PackageReference Include="Jaeger" Version="0.2.1" /-->
   </ItemGroup>


### PR DESCRIPTION
## Which problem is this PR solving?
First time learners need to break dependency from example project to parent project. 

## Short description of the changes
I know binding example application directly to the current available version is more appropriate; however, giving an example to use NuGet package could be useful.