### PR TITLE
Enrich the ways one can configure Jaeger with ASP.Net's IConfiguration

### DIFF
--- a/src/Jaeger/Jaeger.csproj
+++ b/src/Jaeger/Jaeger.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="OpenTracing" Version="0.12.0" />
   </ItemGroup>

--- a/test/Jaeger.Tests/Jaeger.Tests.csproj
+++ b/test/Jaeger.Tests/Jaeger.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Have multiple ways in which Jaeger can be _easily_ configured, not only through Environment Variables.

## Short description of the changes
- Sometimes it's very useful to use other configuration providers and IConfiguration offers this possibility.

see https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1

