### PR TITLE
Change authorization header key to be the standard 'Authorization'

### DIFF
--- a/src/Jaeger/Senders/HttpSender.cs
+++ b/src/Jaeger/Senders/HttpSender.cs
@@ -42,7 +42,7 @@ namespace Jaeger.Senders
             var customHeaders = new Dictionary<string, string>();
             if (builder.AuthenticationHeaderValue != null)
             {
-                customHeaders.Add("Authorize", builder.AuthenticationHeaderValue.ToString());
+                customHeaders.Add("Authorization", builder.AuthenticationHeaderValue.ToString());
             }
 
             _transport = new THttpClientTransport(collectorUri, customHeaders);


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves [#113](https://github.com/jaegertracing/jaeger-client-csharp/issues/113)

## Short description of the changes
- Changed HttpSender Authorization header key from `Authorize` to `Authorization`
