### PR TITLE
Adding identifying info to warning logging

### DIFF
--- a/src/Jaeger/Span.cs
+++ b/src/Jaeger/Span.cs
@@ -118,7 +118,7 @@ namespace Jaeger
             {
                 if (FinishTimestampUtc != null)
                 {
-                    Tracer.Logger.LogWarning("Span has already been finished; will not be reported again.");
+                    Tracer.Logger.LogWarning("Span has already been finished; will not be reported again. Operation: {0} Trace Id: {1} Span Id: {2}", OperationName, Context.TraceId, Context.SpanId);
                     return;
                 }
                 FinishTimestampUtc = finishTimestampUtc;

--- a/src/Jaeger/Span.cs
+++ b/src/Jaeger/Span.cs
@@ -118,7 +118,7 @@ namespace Jaeger
             {
                 if (FinishTimestampUtc != null)
                 {
-                    Tracer.Logger.LogWarning("Span has already been finished; will not be reported again. Operation: {0} Trace Id: {1} Span Id: {2}", OperationName, Context.TraceId, Context.SpanId);
+                    Tracer.Logger.LogWarning("Span has already been finished; will not be reported again. Operation: {operationName} Trace Id: {traceId} Span Id: {spanId}", OperationName, Context.TraceId, Context.SpanId);
                     return;
                 }
                 FinishTimestampUtc = finishTimestampUtc;


### PR DESCRIPTION
It is difficult to identify which is the offending span from the current log line. This change is to include information to easily identify which span needs to be addressed; either through a common operation triggers multiple warning log lines or through the specific trace/span id that can be investigated through the dashboard.

Signed-off-by: rwkarg <rwkarg@gmail.com>


## Which problem is this PR solving?
- Resolves #125

## Short description of the changes
- Add Operation Name and Trace/Span Id to Warning logging
