### PR TITLE
Made WithTraceId128Bit public and added Tests

### DIFF
--- a/src/Jaeger/Configuration.cs
+++ b/src/Jaeger/Configuration.cs
@@ -269,7 +269,7 @@ namespace Jaeger
             return this;
         }
 
-        private Configuration WithTraceId128Bit(bool useTraceId128Bit)
+        public Configuration WithTraceId128Bit(bool useTraceId128Bit)
         {
             _useTraceId128Bit = useTraceId128Bit;
             return this;

--- a/test/Jaeger.Tests/ConfigurationTests.cs
+++ b/test/Jaeger.Tests/ConfigurationTests.cs
@@ -444,6 +444,24 @@ namespace Jaeger.Tests
         }
 
         [Fact]
+        public void TestUseTraceId128BitFromEnv()
+        {
+            SetProperty(Configuration.JaegerServiceName, "Test");
+            SetProperty(Configuration.JaegerTraceId128Bit, "true");
+            Tracer tracer = (Tracer)Configuration.FromEnv(_loggerFactory).GetTracer();
+            Assert.True(tracer.UseTraceId128Bit);
+        }
+
+        [Fact]
+        public void TestUseTraceId128BitFromConfig()
+        {
+            Tracer tracer = (Tracer)new Configuration("Test", _loggerFactory)
+                .WithTraceId128Bit(true)
+                .GetTracer();
+            Assert.True(tracer.UseTraceId128Bit);
+        }
+
+        [Fact]
         public void TestNoServiceName()
         {
             Assert.Throws<ArgumentException>(() => new Configuration(null, _loggerFactory));


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #112

## Short description of the changes
- #94 added the `WithTraceId128Bit` method to `Configuration`, but it was still `private` for no reason.
