### PR TITLE
Fix collection was modified error

### DIFF
--- a/src/Jaeger/Reporters/Protocols/JaegerThriftSpanConverter.cs
+++ b/src/Jaeger/Reporters/Protocols/JaegerThriftSpanConverter.cs
@@ -9,6 +9,7 @@ using ThriftReference = Jaeger.Thrift.SpanRef;
 using ThriftReferenceType = Jaeger.Thrift.SpanRefType;
 using ThriftLog = Jaeger.Thrift.Log;
 using ThriftTagType = Jaeger.Thrift.TagType;
+using System.Linq;
 
 namespace Jaeger.Reporters.Protocols
 {

--- a/src/Jaeger/Reporters/Protocols/JaegerThriftSpanConverter.cs
+++ b/src/Jaeger/Reporters/Protocols/JaegerThriftSpanConverter.cs
@@ -66,7 +66,7 @@ namespace Jaeger.Reporters.Protocols
             List<ThriftLog> thriftLogs = new List<ThriftLog>();
             if (logs != null)
             {
-                foreach (LogData logData in logs)
+                foreach (LogData logData in logs.ToArray())
                 {
                     ThriftLog thriftLog = new ThriftLog();
                     thriftLog.Timestamp = logData.TimestampUtc.ToUnixTimeMicroseconds();
@@ -94,7 +94,7 @@ namespace Jaeger.Reporters.Protocols
             var thriftTags = new List<ThriftTag>();
             if (tags != null)
             {
-                foreach (var tag in tags)
+                foreach (var tag in tags.ToArray())
                 {
                     thriftTags.Add(BuildTag(tag.Key, tag.Value));
                 }


### PR DESCRIPTION
Cause possible this error
ERROR|Jaeger.Reporters.RemoteReporter|QueueProcessor error ░
System.InvalidOperationException: Collection was modified; enumeration operation may not execute. ░
at System.Collections.Generic.List`1.Enumerator.MoveNextRare() ░
at Jaeger.Reporters.Protocols.JaegerThriftSpanConverter.BuildLogs(IEnumerable`1 logs) ░
at Jaeger.Reporters.Protocols.JaegerThriftSpanConverter.ConvertSpan(Span span) ░
at Jaeger.Senders.ThriftSender.AppendAsync(Span span, CancellationToken cancellationToken) ░
at Jaeger.Reporters.RemoteReporter.ProcessQueueLoop()

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Solve collection was modified exception

## Short description of the changes
-
