### PR TITLE
Made Span.GetTags and Span.GetLogs immutable

### DIFF
--- a/src/Jaeger/Reporters/InMemoryReporter.cs
+++ b/src/Jaeger/Reporters/InMemoryReporter.cs
@@ -21,7 +21,7 @@ namespace Jaeger.Reporters
         {
             lock (_lock)
             {
-                return new List<Span>(_spans).AsReadOnly();
+                return new List<Span>(_spans);
             }
         }
 

--- a/src/Jaeger/Reporters/InMemoryReporter.cs
+++ b/src/Jaeger/Reporters/InMemoryReporter.cs
@@ -21,7 +21,7 @@ namespace Jaeger.Reporters
         {
             lock (_lock)
             {
-                return _spans;
+                return new List<Span>(_spans).AsReadOnly();
             }
         }
 

--- a/src/Jaeger/Span.cs
+++ b/src/Jaeger/Span.cs
@@ -10,6 +10,7 @@ namespace Jaeger
     public class Span : ISpan
     {
         private static readonly IReadOnlyList<LogData> EmptyLogs = new List<LogData>().AsReadOnly();
+        private static readonly IReadOnlyDictionary<string, object> EmptyTags = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
         private static readonly IReadOnlyList<Reference> EmptyReferences = new List<Reference>().AsReadOnly();
 
         private readonly object _lock = new object();
@@ -54,7 +55,18 @@ namespace Jaeger
 
         public IReadOnlyList<Reference> GetReferences() => _references;
 
-        public IReadOnlyDictionary<string, object> GetTags() => new Dictionary<string, object>(_tags);
+        public IReadOnlyDictionary<string, object> GetTags()
+        {
+            lock (_lock)
+            {
+                if (_tags == null)
+                {
+                    return EmptyTags;
+                }
+
+                return new Dictionary<string, object>(_tags);
+            }
+        }
 
         public ISpan SetOperationName(string operationName)
         {

--- a/src/Jaeger/Span.cs
+++ b/src/Jaeger/Span.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Microsoft.Extensions.Logging;
 using OpenTracing;
 using OpenTracing.Tag;
@@ -53,7 +54,7 @@ namespace Jaeger
 
         public IReadOnlyList<Reference> GetReferences() => _references;
 
-        public IReadOnlyDictionary<string, object> GetTags() => _tags;
+        public IReadOnlyDictionary<string, object> GetTags() => new Dictionary<string, object>(_tags);
 
         public ISpan SetOperationName(string operationName)
         {
@@ -73,7 +74,12 @@ namespace Jaeger
         {
             lock (_lock)
             {
-                return _logs ?? EmptyLogs;
+                if (_logs == null)
+                {
+                    return EmptyLogs;
+                }
+
+                return new List<LogData>(_logs).AsReadOnly();
             }
         }
 

--- a/src/Jaeger/Span.cs
+++ b/src/Jaeger/Span.cs
@@ -79,7 +79,7 @@ namespace Jaeger
                     return EmptyLogs;
                 }
 
-                return new List<LogData>(_logs).AsReadOnly();
+                return new List<LogData>(_logs);
             }
         }
 

--- a/test/Jaeger.Tests/SpanTests.cs
+++ b/test/Jaeger.Tests/SpanTests.cs
@@ -119,6 +119,20 @@ namespace Jaeger.Tests
         }
 
         [Fact]
+        public void TestGetTags_IsImmutable()
+        {
+            string expected = "expected.value";
+            string key = "tag.key";
+            
+            var oldTags = span.GetTags();
+            span.SetTag(key, expected);
+
+            var newTags = span.GetTags();
+            Assert.Equal(expected, newTags[key]);
+            Assert.NotEqual(oldTags, newTags);
+        }
+
+        [Fact]
         public void TestSetStringTag()
         {
             string expected = "expected.value";
@@ -233,6 +247,20 @@ namespace Jaeger.Tests
             Assert.Equal(expectedTimestamp, actualLogData.TimestampUtc);
             Assert.Null(actualLogData.Message);
             Assert.Equal(expectedFields, actualLogData.Fields);
+        }
+
+        [Fact]
+        public void TestGetLogs_IsImmutable()
+        {
+            string expectedEvent = "expectedEvent";
+
+            var oldLogs = span.GetLogs();
+            Assert.Empty(oldLogs);
+            span.Log(expectedEvent);
+
+            var newLogs = span.GetLogs();
+            Assert.Empty(oldLogs);
+            Assert.NotEmpty(newLogs);
         }
 
         [Fact]


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #129 

## Short description of the changes
- `Span.GetTags()` and `Span.GetLogs()` could be modified while iterating over them.
- Creating copies of the list when necessary. `Span.GetReferences()` and most other locations are not affected since they can't be modified by public methods.