### PR TITLE
- Fix long overflow problem if probabilistic sampler param equals 1.0

### DIFF
--- a/src/Jaeger/Samplers/ProbabilisticSampler.cs
+++ b/src/Jaeger/Samplers/ProbabilisticSampler.cs
@@ -26,11 +26,20 @@ namespace Jaeger.Samplers
 
             SamplingRate = samplingRate;
 
-            // Note: Java uses bit shifting but that code results in a compiler warning in C#.
-            // We could enclose it in an `unchecked` block but we're using this code
-            // as it's more readable.
-            _positiveSamplingBoundary = (long)(long.MaxValue * samplingRate);
-            _negativeSamplingBoundary = (long)(long.MinValue * samplingRate);
+            // Check possible long overflow (if sampling param 1.0)
+            if (Math.Abs(samplingRate - 1.0) < 0.00001)
+            {
+                _positiveSamplingBoundary = long.MaxValue;
+                _negativeSamplingBoundary = long.MinValue;
+            }
+            else
+            {
+                // Note: Java uses bit shifting but that code results in a compiler warning in C#.
+                // We could enclose it in an `unchecked` block but we're using this code
+                // as it's more readable.
+                _positiveSamplingBoundary = (long)(long.MaxValue * samplingRate);
+                _negativeSamplingBoundary = (long)(long.MinValue * samplingRate);
+            }
 
             _tags = new Dictionary<string, object> {
                 { Constants.SamplerTypeTagKey, Type },


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fix long overflow problem if probabilistic sampler param equals 1.0

## Short description of the changes
- Check sampling param and set long.MaxValue and long.MinValue if sampler param equals 1.0