### PR TITLE
Add GrpcSender for jaeger-collector

### DIFF
--- a/Jaeger.sln
+++ b/Jaeger.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jaeger.Example.WebApi", "ex
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jaeger.Example.WebApi.NetFx", "examples\Jaeger.Example.WebApi.NetFx\Jaeger.Example.WebApi.NetFx.csproj", "{4984D8D3-E8FE-4AC8-B285-AC041CB9B30F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jaeger.Grpc", "src\Jaeger.Grpc\Jaeger.Grpc.csproj", "{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -149,6 +151,18 @@ Global
 		{4984D8D3-E8FE-4AC8-B285-AC041CB9B30F}.Release|x64.Build.0 = Release|Any CPU
 		{4984D8D3-E8FE-4AC8-B285-AC041CB9B30F}.Release|x86.ActiveCfg = Release|Any CPU
 		{4984D8D3-E8FE-4AC8-B285-AC041CB9B30F}.Release|x86.Build.0 = Release|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Debug|x64.Build.0 = Debug|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Debug|x86.Build.0 = Debug|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Release|x64.ActiveCfg = Release|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Release|x64.Build.0 = Release|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Release|x86.ActiveCfg = Release|Any CPU
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -166,6 +180,7 @@ Global
 		{ABA4F1B1-F6D0-40A9-904B-EFA98A4C0411} = {4FB0DAC9-D8C6-4368-B48E-363FA85029A4}
 		{258F726B-6E51-4F18-9FB6-41D09A836904} = {1ADE2BBF-56C4-433D-9B1C-A532915058D3}
 		{4984D8D3-E8FE-4AC8-B285-AC041CB9B30F} = {1ADE2BBF-56C4-433D-9B1C-A532915058D3}
+		{88AA7284-3D74-4CBD-83C8-85ADD05A3AC4} = {4FB0DAC9-D8C6-4368-B48E-363FA85029A4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {83668757-63F5-48E3-A8E0-8AED6B7562D0}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Property | Required | Description
 JAEGER_SERVICE_NAME | yes | The service name
 JAEGER_AGENT_HOST | no | The hostname for communicating with agent via UDP
 JAEGER_AGENT_PORT | no | The port for communicating with agent via UDP
+JAEGER_GRPC_HOST  | no | The hostname for communicating with collector via GRPC
+JAEGER_GRPC_PORT  | no | The port for communicating with collector via GRPC
 JAEGER_ENDPOINT | no | The traces endpoint, in case the client should connect directly to the Collector, like http://jaeger-collector:14268/api/traces
 JAEGER_AUTH_TOKEN | no | Authentication Token to send as "Bearer" to the endpoint
 JAEGER_USER | no | Username to send as part of "Basic" authentication to the endpoint

--- a/src/Jaeger.Grpc/Jaeger.Grpc.csproj
+++ b/src/Jaeger.Grpc/Jaeger.Grpc.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <!-- No XML docs as this library contains auto-generated code that doesn't produce useful XML comments -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.7.0" />
+    <PackageReference Include="Grpc" Version="1.19.0" />
+    <PackageReference Include="Grpc.Tools" Version="1.19.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProtoBuf Include="**/*.proto" />
+  </ItemGroup>
+
+</Project>

--- a/src/Jaeger.Grpc/protos/api_v2/collector.proto
+++ b/src/Jaeger.Grpc/protos/api_v2/collector.proto
@@ -1,0 +1,31 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax="proto3";
+
+package jaeger.api_v2;
+
+import "protos/model.proto";
+
+message PostSpansRequest {
+    Batch batch = 1;
+}
+
+message PostSpansResponse {
+}
+
+service CollectorService {
+    rpc PostSpans(PostSpansRequest) returns (PostSpansResponse);
+}

--- a/src/Jaeger.Grpc/protos/api_v2/sampling.proto
+++ b/src/Jaeger.Grpc/protos/api_v2/sampling.proto
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax="proto3";
+
+package jaeger.api_v2;
+
+enum SamplingStrategyType {
+  PROBABILISTIC = 0;
+  RATE_LIMITING = 1;
+};
+
+message ProbabilisticSamplingStrategy {
+  double samplingRate = 1;
+}
+
+message RateLimitingSamplingStrategy {
+  int32 maxTracesPerSecond = 1;
+}
+
+message OperationSamplingStrategy {
+  string operation = 1;
+  ProbabilisticSamplingStrategy probabilisticSampling = 2;
+}
+
+message PerOperationSamplingStrategies {
+  double defaultSamplingProbability = 1;
+  double defaultLowerBoundTracesPerSecond = 2;
+  repeated OperationSamplingStrategy perOperationStrategies = 3;
+  double defaultUpperBoundTracesPerSecond = 4;
+}
+
+message SamplingStrategyResponse {
+  SamplingStrategyType strategyType = 1;
+  ProbabilisticSamplingStrategy probabilisticSampling = 2;
+  RateLimitingSamplingStrategy rateLimitingSampling = 3;
+  PerOperationSamplingStrategies operationSampling =4;
+}
+
+message SamplingStrategyParameters {
+  string serviceName = 1;
+}
+
+service SamplingManager {
+  rpc GetSamplingStrategy(SamplingStrategyParameters) returns (SamplingStrategyResponse);
+}

--- a/src/Jaeger.Grpc/protos/model.proto
+++ b/src/Jaeger.Grpc/protos/model.proto
@@ -1,0 +1,89 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax="proto3";
+
+package jaeger.api_v2;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+enum ValueType {
+  STRING  = 0;
+  BOOL    = 1;
+  INT64   = 2;
+  FLOAT64 = 3;
+  BINARY  = 4;
+};
+
+message KeyValue {
+  string    key       = 1;
+  ValueType v_type    = 2;
+  string    v_str     = 3;
+  bool      v_bool    = 4;
+  int64     v_int64   = 5;
+  double    v_float64 = 6;
+  bytes     v_binary  = 7;
+}
+
+message Log {
+  google.protobuf.Timestamp timestamp = 1;
+  repeated KeyValue fields = 2;
+}
+
+enum SpanRefType {
+  CHILD_OF = 0;
+  FOLLOWS_FROM = 1;
+};
+
+message SpanRef {
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  SpanRefType ref_type = 3;
+}
+
+message Process {
+  string service_name = 1;
+  repeated KeyValue tags = 2;
+}
+
+message Span {
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  string operation_name = 3;
+  repeated SpanRef references = 4;
+  uint32 flags = 5;
+  google.protobuf.Timestamp start_time = 6;
+  google.protobuf.Duration duration = 7;
+  repeated KeyValue tags = 8;
+  repeated Log logs = 9;
+  Process process = 10;
+  string process_id = 11;
+  repeated string warnings = 12;
+}
+
+message Trace {
+  message ProcessMapping {
+      string process_id = 1;
+      Process process = 2;
+  }
+  repeated Span spans = 1;
+  repeated ProcessMapping process_map = 2;
+  repeated string warnings = 3;
+}
+
+message Batch {
+    repeated Span spans = 1;
+    Process process = 2;
+}

--- a/src/Jaeger/Configuration.cs
+++ b/src/Jaeger/Configuration.cs
@@ -717,21 +717,19 @@ namespace Jaeger
             /// <returns>The sender passed via the constructor or a properly configured sender.</returns>
             public virtual ISender GetSender()
             {
-                // if we have a sender, that's the one we return
                 if (Sender != null)
                 {
+                    // If we have a sender, that's the one we return
                     return Sender;
                 }
-
-                // if we have an HTTP endpoint, return that one
                 if (!string.IsNullOrEmpty(Endpoint))
                 {
+                    // If we have an HTTP endpoint, return that one
                     return GetHttpSender();
                 }
-
-                // if we have an GRPC endpoint, return that one
                 if (!string.IsNullOrEmpty(GrpcHost))
                 {
+                    // If we have an GRPC endpoint, return that one
                     return GetGrpcSender();
                 }
 

--- a/src/Jaeger/Jaeger.csproj
+++ b/src/Jaeger/Jaeger.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Jaeger.Thrift\Jaeger.Thrift.csproj" />
+      <ProjectReference Include="..\Jaeger.Grpc\Jaeger.Grpc.csproj" />
+      <ProjectReference Include="..\Jaeger.Thrift\Jaeger.Thrift.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jaeger/Reporters/Protocols/JaegerGrpcSpanConverter.cs
+++ b/src/Jaeger/Reporters/Protocols/JaegerGrpcSpanConverter.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using OpenTracing;
+using GrpcSpan = Jaeger.ApiV2.Span;
+using GrpcTag = Jaeger.ApiV2.KeyValue;
+using GrpcReference = Jaeger.ApiV2.SpanRef;
+using GrpcReferenceType = Jaeger.ApiV2.SpanRefType;
+using GrpcLog = Jaeger.ApiV2.Log;
+using GrpcTagType = Jaeger.ApiV2.ValueType;
+
+namespace Jaeger.Reporters.Protocols
+{
+    public static class JaegerGrpcSpanConverter
+    {
+        public static GrpcSpan ConvertSpan(Span span)
+        {
+            var context = span.Context;
+            var startTime = span.StartTimestampUtc;
+            var duration = (span.FinishTimestampUtc ?? startTime) - startTime;
+
+            var references = span.GetReferences();
+            var oneChildOfParent = references.Count == 1 && string.Equals(References.ChildOf, references[0].Type, StringComparison.Ordinal);
+
+            var grpcSpan = new GrpcSpan
+            {
+                TraceId = ByteString.CopyFrom(context.TraceId.ToByteArray()),
+                SpanId = ByteString.CopyFrom(context.SpanId.ToByteArray()),
+                OperationName = span.OperationName,
+                Flags = (uint)context.Flags,
+                StartTime = Timestamp.FromDateTime(startTime),
+                Duration = Duration.FromTimeSpan(duration),
+                References = { oneChildOfParent ? new List<GrpcReference>() : BuildReferences(references) },
+                Tags = { BuildTags(span.GetTags()) },
+                Logs = { BuildLogs(span.GetLogs()) }
+            };
+
+            return grpcSpan;
+        }
+
+        internal static List<GrpcReference> BuildReferences(IReadOnlyList<Reference> references)
+        {
+            List<GrpcReference> grpcReferences = new List<GrpcReference>(references.Count);
+            foreach (var reference in references)
+            {
+                GrpcReferenceType grpcRefType = string.Equals(References.ChildOf, reference.Type, StringComparison.Ordinal)
+                    ? GrpcReferenceType.ChildOf
+                    : GrpcReferenceType.FollowsFrom;
+
+                grpcReferences.Add(new GrpcReference
+                {
+                    RefType = grpcRefType,
+                    TraceId = ByteString.CopyFrom(reference.Context.TraceId.ToByteArray()),
+                    SpanId = ByteString.CopyFrom(reference.Context.SpanId.ToByteArray())
+                });
+            }
+
+            return grpcReferences;
+        }
+
+        private static List<GrpcLog> BuildLogs(IEnumerable<LogData> logs)
+        {
+            List<GrpcLog> grpcLogs = new List<GrpcLog>();
+            if (logs != null)
+            {
+                foreach (LogData logData in logs)
+                {
+                    GrpcLog grpcLog = new GrpcLog
+                    {
+                        Timestamp = Timestamp.FromDateTime(logData.TimestampUtc)
+                    };
+
+                    if (logData.Fields != null)
+                    {
+                        grpcLog.Fields.AddRange(BuildTags(logData.Fields));
+                    }
+                    else if (logData.Message != null)
+                    {
+                        grpcLog.Fields.Add(BuildTag(LogFields.Event, logData.Message));
+                    }
+
+                    grpcLogs.Add(grpcLog);
+                }
+            }
+            return grpcLogs;
+        }
+
+        internal static List<GrpcTag> BuildTags(IEnumerable<KeyValuePair<string, object>> tags)
+        {
+            var grpcTags = new List<GrpcTag>();
+            if (tags != null)
+            {
+                foreach (var tag in tags)
+                {
+                    grpcTags.Add(BuildTag(tag.Key, tag.Value));
+                }
+            }
+            return grpcTags;
+        }
+
+        internal static GrpcTag BuildTag(string key, object value)
+        {
+            switch (value)
+            {
+                case byte[] val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Binary, VBinary = ByteString.CopyFrom(val) };
+                case double val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Float64, VFloat64 = val };
+                case decimal val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Float64, VFloat64 = (double)val };
+                case float val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Float64, VFloat64 = val };
+                case bool val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Bool, VBool = val };
+                case ushort val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Int64, VInt64 = val };
+                case uint val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Int64, VInt64 = val };
+                case ulong val when val <= long.MaxValue:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Int64, VInt64 = (long)val };
+                case short val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Int64, VInt64 = val };
+                case int val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Int64, VInt64 = val };
+                case long val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.Int64, VInt64 = val };
+                case string val:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.String, VStr = val };
+                default:
+                    return new GrpcTag { Key = key, VType = GrpcTagType.String, VStr = Convert.ToString(value, CultureInfo.InvariantCulture) };
+            }
+        }
+    }
+}

--- a/src/Jaeger/Senders/GrpcSender.cs
+++ b/src/Jaeger/Senders/GrpcSender.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Jaeger.ApiV2;
+using Jaeger.Exceptions;
+using Jaeger.Reporters.Protocols;
+using GrpcProcess = Jaeger.ApiV2.Process;
+using GrpcSpan = Jaeger.ApiV2.Span;
+
+namespace Jaeger.Senders
+{
+    /// <summary>
+    /// GrpcSender provides an implementation to transport spans over HTTP using
+    /// GRPC.
+    /// </summary>
+    public class GrpcSender : ISender
+    {
+        public const string DefaultCollectorGrpcHost = "localhost";
+        public const int DefaultCollectorGrpcPort = 14250;
+
+        private readonly Channel _channel;
+        private readonly CollectorService.CollectorServiceClient _client;
+        private GrpcProcess _process;
+        private readonly List<GrpcSpan> _spanBuffer = new List<GrpcSpan>();
+
+        /// <summary>
+        /// This constructor expects Jaeger running on <see cref="DefaultCollectorGrpcHost"/>
+        /// and port <see cref="DefaultCollectorGrpcPort"/> without credentials.
+        /// </summary>
+        public GrpcSender()
+            : this(DefaultCollectorGrpcHost, DefaultCollectorGrpcPort, ChannelCredentials.Insecure)
+        {
+        }
+
+        /// <param name="host">If empty it will use <see cref="DefaultCollectorGrpcHost"/>.</param>
+        /// <param name="port">If 0 it will use <see cref="DefaultCollectorGrpcPort"/>.</param>
+        /// <param name="credentials">If empty it will use <see cref="ChannelCredentials.Insecure"/>.</param>
+        public GrpcSender(string host, int port, ChannelCredentials credentials)
+        {
+
+            if (string.IsNullOrEmpty(host))
+            {
+                host = DefaultCollectorGrpcHost;
+            }
+
+            if (port == 0)
+            {
+                port = DefaultCollectorGrpcPort;
+            }
+
+            if (credentials == null)
+            {
+                credentials = ChannelCredentials.Insecure;
+            }
+
+            _channel = new Channel(host, port, credentials);
+            _client = new CollectorService.CollectorServiceClient(_channel);
+        }
+
+        public Task<int> AppendAsync(Span span, CancellationToken cancellationToken)
+        {
+            if (_process == null)
+            {
+                _process = new GrpcProcess
+                {
+                    ServiceName = span.Tracer.ServiceName,
+                    Tags = { JaegerGrpcSpanConverter.BuildTags(span.Tracer.Tags) }
+                };
+            }
+
+            GrpcSpan grpcSpan = JaegerGrpcSpanConverter.ConvertSpan(span);
+            _spanBuffer.Add(grpcSpan);
+
+            return Task.FromResult(0);
+        }
+
+        public async Task<int> FlushAsync(CancellationToken cancellationToken)
+        {
+            if (_spanBuffer.Count == 0)
+            {
+                return 0;
+            }
+
+            int n = _spanBuffer.Count;
+            try
+            {
+                var request = new PostSpansRequest
+                {
+                    Batch = new Batch
+                    {
+                        Process = _process,
+                        Spans = { _spanBuffer }
+                    }
+                };
+                await _client.PostSpansAsync(request, cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new SenderException("Failed to flush spans.", ex, n);
+            }
+            finally
+            {
+                _spanBuffer.Clear();
+            }
+            return n;
+        }
+
+        public virtual Task<int> CloseAsync(CancellationToken cancellationToken)
+        {
+            return FlushAsync(cancellationToken);
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(GrpcSender)}()";
+        }
+    }
+}

--- a/src/Jaeger/SpanId.cs
+++ b/src/Jaeger/SpanId.cs
@@ -26,14 +26,19 @@ namespace Jaeger
             Id = traceId.Low;
         }
 
-        public override string ToString()
-        {
-            return Id.ToString("x");
-        }
-
         public static implicit operator long(SpanId s)
         {
             return s.Id;
+        }
+
+        public byte[] ToByteArray()
+        {
+            return Utils.LongToNetworkBytes(Id);
+        }
+
+        public override string ToString()
+        {
+            return Id.ToString("x");
         }
 
         public static SpanId FromString(string from)

--- a/src/Jaeger/TraceId.cs
+++ b/src/Jaeger/TraceId.cs
@@ -40,6 +40,18 @@ namespace Jaeger
             return $"{High:x}{Low:x016}";
         }
 
+        public byte[] ToByteArray()
+        {
+            var bytesHigh = Utils.LongToNetworkBytes(High);
+            var bytesLow = Utils.LongToNetworkBytes(Low);
+
+            var bytes = new byte[bytesHigh.Length + bytesLow.Length];
+            Array.Copy(bytesHigh, 0, bytes, 0, bytesHigh.Length);
+            Array.Copy(bytesLow, 0, bytes, bytesHigh.Length, bytesLow.Length);
+
+            return bytes;
+        }
+
         public static TraceId FromString(string from)
         {
             if (from.Length > 32)

--- a/src/Jaeger/Util/Utils.cs
+++ b/src/Jaeger/Util/Utils.cs
@@ -51,5 +51,15 @@ namespace Jaeger.Util
             }
             return value;
         }
+
+        public static byte[] LongToNetworkBytes(long data)
+        {
+            var bytes = BitConverter.GetBytes(data);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+            return bytes;
+        }
     }
 }

--- a/test/Jaeger.Tests/ConfigurationTests.cs
+++ b/test/Jaeger.Tests/ConfigurationTests.cs
@@ -43,6 +43,9 @@ namespace Jaeger.Tests
             // Explicitly clear all properties
             ClearProperty(Configuration.JaegerAgentHost);
             ClearProperty(Configuration.JaegerAgentPort);
+            ClearProperty(Configuration.JaegerGrpcHost);
+            ClearProperty(Configuration.JaegerGrpcPort);
+            ClearProperty(Configuration.JaegerGrpcRootCertificate);
             ClearProperty(Configuration.JaegerReporterLogSpans);
             ClearProperty(Configuration.JaegerReporterMaxQueueSize);
             ClearProperty(Configuration.JaegerReporterFlushInterval);
@@ -246,7 +249,16 @@ namespace Jaeger.Tests
         {
             SetProperty(Configuration.JaegerEndpoint, "https://jaeger-collector:14268/api/traces");
             ISender sender = Configuration.SenderConfiguration.FromEnv(_loggerFactory).GetSender();
-            Assert.True(sender is HttpSender);
+            Assert.IsType<HttpSender>(sender);
+        }
+
+        [Fact]
+        public void TestSenderWithGrpcDataFromEnv()
+        {
+            SetProperty(Configuration.JaegerGrpcHost, "jaeger-collector");
+            SetProperty(Configuration.JaegerGrpcPort, "14250");
+            ISender sender = Configuration.SenderConfiguration.FromEnv(_loggerFactory).GetSender();
+            Assert.IsType<GrpcSender>(sender);
         }
 
         [Fact]
@@ -292,7 +304,7 @@ namespace Jaeger.Tests
                     .WithEndpoint("https://jaeger-collector:14268/api/traces")
                     .WithAuthUsername("username")
                     .WithAuthPassword("password");
-            Assert.True(senderConfiguration.GetSender() is HttpSender);
+            Assert.IsType<HttpSender>(senderConfiguration.GetSender());
         }
 
         [Fact]
@@ -301,17 +313,30 @@ namespace Jaeger.Tests
             Configuration.SenderConfiguration senderConfiguration = new Configuration.SenderConfiguration(_loggerFactory)
                     .WithEndpoint("https://jaeger-collector:14268/api/traces")
                     .WithAuthToken("authToken");
-            Assert.True(senderConfiguration.GetSender() is HttpSender);
+            Assert.IsType<HttpSender>(senderConfiguration.GetSender());
         }
 
         [Fact]
         public void TestSenderWithAllPropertiesReturnsHttpSender()
         {
             SetProperty(Configuration.JaegerEndpoint, "https://jaeger-collector:14268/api/traces");
+            SetProperty(Configuration.JaegerGrpcHost, "jaeger-collector");
+            SetProperty(Configuration.JaegerGrpcPort, "14250");
             SetProperty(Configuration.JaegerAgentHost, "jaeger-agent");
             SetProperty(Configuration.JaegerAgentPort, "6832");
 
-            Assert.True(Configuration.SenderConfiguration.FromEnv(_loggerFactory).GetSender() is HttpSender);
+            Assert.IsType<HttpSender>(Configuration.SenderConfiguration.FromEnv(_loggerFactory).GetSender());
+        }
+
+        [Fact]
+        public void TestSenderWithGrpcAndAgentDataReturnsGrpcSender()
+        {
+            SetProperty(Configuration.JaegerGrpcHost, "jaeger-collector");
+            SetProperty(Configuration.JaegerGrpcPort, "14250");
+            SetProperty(Configuration.JaegerAgentHost, "jaeger-agent");
+            SetProperty(Configuration.JaegerAgentPort, "6832");
+
+            Assert.IsType<GrpcSender>(Configuration.SenderConfiguration.FromEnv(_loggerFactory).GetSender());
         }
 
         [Fact]
@@ -494,7 +519,7 @@ namespace Jaeger.Tests
                 .WithType(ConstSampler.Type);
             ISampler sampler = samplerConfiguration.GetSampler("name",
                 new MetricsImpl(NoopMetricsFactory.Instance));
-            Assert.True(sampler is ConstSampler);
+            Assert.IsType<ConstSampler>(sampler);
         }
 
         [Fact]
@@ -504,7 +529,7 @@ namespace Jaeger.Tests
                 .WithType(ProbabilisticSampler.Type);
             ISampler sampler = samplerConfiguration.GetSampler("name",
                 new MetricsImpl(NoopMetricsFactory.Instance));
-            Assert.True(sampler is ProbabilisticSampler);
+            Assert.IsType<ProbabilisticSampler>(sampler);
         }
 
         [Fact]
@@ -514,7 +539,7 @@ namespace Jaeger.Tests
                 .WithType(RateLimitingSampler.Type);
             ISampler sampler = samplerConfiguration.GetSampler("name",
                 new MetricsImpl(NoopMetricsFactory.Instance));
-            Assert.True(sampler is RateLimitingSampler);
+            Assert.IsType<RateLimitingSampler>(sampler);
         }
 
         internal class TestTextMap : ITextMap

--- a/test/Jaeger.Tests/Reporters/Protocols/JaegerGrpcSpanConverterTests.cs
+++ b/test/Jaeger.Tests/Reporters/Protocols/JaegerGrpcSpanConverterTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using Jaeger.Reporters;
+using Jaeger.Reporters.Protocols;
+using Jaeger.Samplers;
+using OpenTracing;
+using Xunit;
+using GrpcSpan = Jaeger.ApiV2.Span;
+using GrpcTag = Jaeger.ApiV2.KeyValue;
+using GrpcReference = Jaeger.ApiV2.SpanRef;
+using GrpcLog = Jaeger.ApiV2.Log;
+using GrpcTagType = Jaeger.ApiV2.ValueType;
+
+namespace Jaeger.Tests.Reporters.Protocols
+{
+    public class JaegerGrpcSpanConverterTests
+    {
+        private readonly Tracer _tracer;
+
+        public JaegerGrpcSpanConverterTests()
+        {
+            _tracer = new Tracer.Builder("test-service-name")
+                .WithReporter(new InMemoryReporter())
+                .WithSampler(new ConstSampler(true))
+                .Build();
+        }
+
+        public static List<object[]> DataProviderBuildTag() => new List<object[]>
+        {
+            new object[] { "value", GrpcTagType.String, "value" },
+            new object[] { (long) 1, GrpcTagType.Int64, (long) 1 },
+            new object[] { 1, GrpcTagType.Int64, (long) 1 },
+            new object[] { (short) 1, GrpcTagType.Int64, (long) 1 },
+            new object[] { (double) 1, GrpcTagType.Float64, (double) 1 },
+            new object[] { (float) 1, GrpcTagType.Float64, (double) 1 },
+            new object[] { (byte) 1, GrpcTagType.String, "1" },
+            new object[] { true, GrpcTagType.Bool, true },
+            // TODO C# doesn't use values for ToString() // new object[] { new List<string> { "hello" }, GrpcTagType.STRING, "[hello]" },
+            new object[] { new List<string> { "hello" }, GrpcTagType.String, "System.Collections.Generic.List`1[System.String]" }
+        };
+
+        [Theory]
+        [MemberData(nameof(DataProviderBuildTag))]
+        public void TestBuildTag(object tagValue, GrpcTagType tagType, object expected)
+        {
+            GrpcTag tag = JaegerGrpcSpanConverter.BuildTag("key", tagValue);
+            Assert.Equal(tagType, tag.VType);
+            Assert.Equal("key", tag.Key);
+            switch (tagType)
+            {
+                case GrpcTagType.Bool:
+                    Assert.Equal(expected, tag.VBool);
+                    break;
+                case GrpcTagType.Int64:
+                    Assert.Equal(expected, tag.VInt64);
+                    break;
+                case GrpcTagType.Float64:
+                    Assert.Equal(expected, tag.VFloat64);
+                    break;
+                case GrpcTagType.Binary:
+                    break;
+                case GrpcTagType.String:
+                default:
+                    Assert.Equal(expected, tag.VStr);
+                    break;
+            }
+        }
+
+        [Fact]
+        public void TestBuildTags()
+        {
+            var tags = new Dictionary<string, object> { { "key", "value" } };
+
+            List<GrpcTag> grpcTags = JaegerGrpcSpanConverter.BuildTags(tags);
+            Assert.NotNull(grpcTags);
+            Assert.Single(grpcTags);
+            Assert.Equal("key", grpcTags[0].Key);
+            Assert.Equal("value", grpcTags[0].VStr);
+            Assert.Equal(GrpcTagType.String, grpcTags[0].VType);
+        }
+
+        [Fact]
+        public void TestConvertSpan()
+        {
+            var logTimestamp = new DateTimeOffset(2018, 4, 13, 10, 30, 0, TimeSpan.Zero);
+            var fields = new Dictionary<string, object> { { "k", "v" } };
+
+            Span span = (Span)_tracer.BuildSpan("operation-name").Start();
+            span.Log(logTimestamp, fields);
+            span.SetBaggageItem("foo", "bar");
+
+            GrpcSpan grpcSpan = JaegerGrpcSpanConverter.ConvertSpan(span);
+
+            Assert.Equal("operation-name", grpcSpan.OperationName);
+            Assert.Equal(2, grpcSpan.Logs.Count);
+            GrpcLog grpcLog = grpcSpan.Logs[0];
+            Assert.Equal(logTimestamp, grpcLog.Timestamp.ToDateTimeOffset());
+            Assert.Single(grpcLog.Fields);
+            GrpcTag grpcTag = grpcLog.Fields[0];
+            Assert.Equal("k", grpcTag.Key);
+            Assert.Equal("v", grpcTag.VStr);
+
+            // NOTE: In Java, the order is different (event, value, key) because the HashMap algorithm is different.
+            grpcLog = grpcSpan.Logs[1];
+            Assert.Equal(3, grpcLog.Fields.Count);
+            grpcTag = grpcLog.Fields[0];
+            Assert.Equal("event", grpcTag.Key);
+            Assert.Equal("baggage", grpcTag.VStr);
+            grpcTag = grpcLog.Fields[1];
+            Assert.Equal("key", grpcTag.Key);
+            Assert.Equal("foo", grpcTag.VStr);
+            grpcTag = grpcLog.Fields[2];
+            Assert.Equal("value", grpcTag.Key);
+            Assert.Equal("bar", grpcTag.VStr);
+        }
+
+        [Fact]
+        public void TestConvertSpanOneReferenceChildOf()
+        {
+            Span parent = (Span)_tracer.BuildSpan("foo").Start();
+
+            Span child = (Span)_tracer.BuildSpan("foo")
+                .AsChildOf(parent)
+                .Start();
+
+            GrpcSpan span = JaegerGrpcSpanConverter.ConvertSpan(child);
+
+            // TODO: Check ParentSpanID
+            //Assert.Equal((long)child.Context.ParentId, span.ParentSpanId);
+            Assert.Empty(span.References);
+        }
+
+        [Fact]
+        public void TestConvertSpanTwoReferencesChildOf()
+        {
+            Span parent = (Span)_tracer.BuildSpan("foo").Start();
+            Span parent2 = (Span)_tracer.BuildSpan("foo").Start();
+
+            Span child = (Span)_tracer.BuildSpan("foo")
+                .AsChildOf(parent)
+                .AsChildOf(parent2)
+                .Start();
+
+            GrpcSpan span = JaegerGrpcSpanConverter.ConvertSpan(child);
+
+            // TODO: Check ParentSpanID
+            //Assert.Equal(0, span.ParentSpanId);
+            Assert.Equal(2, span.References.Count);
+            Assert.Equal(BuildReference(parent.Context, References.ChildOf), span.References[0]);
+            Assert.Equal(BuildReference(parent2.Context, References.ChildOf), span.References[1]);
+        }
+
+        [Fact]
+        public void TestConvertSpanMixedReferences()
+        {
+            Span parent = (Span)_tracer.BuildSpan("foo").Start();
+            Span parent2 = (Span)_tracer.BuildSpan("foo").Start();
+
+            Span child = (Span)_tracer.BuildSpan("foo")
+                .AddReference(References.FollowsFrom, parent.Context)
+                .AsChildOf(parent2)
+                .Start();
+
+            GrpcSpan span = JaegerGrpcSpanConverter.ConvertSpan(child);
+
+            // TODO: Check ParentSpanID
+            //Assert.Equal(0, span.ParentSpanId);
+            Assert.Equal(2, span.References.Count);
+            Assert.Equal(BuildReference(parent.Context, References.FollowsFrom), span.References[0]);
+            Assert.Equal(BuildReference(parent2.Context, References.ChildOf), span.References[1]);
+        }
+
+        private static GrpcReference BuildReference(SpanContext context, string referenceType)
+        {
+            return JaegerGrpcSpanConverter.BuildReferences(new List<Reference> { new Reference(context, referenceType) }.AsReadOnly())[0];
+        }
+    }
+}

--- a/test/Jaeger.Tests/Reporters/Protocols/JaegerThriftSpanConverterTests.cs
+++ b/test/Jaeger.Tests/Reporters/Protocols/JaegerThriftSpanConverterTests.cs
@@ -14,13 +14,13 @@ using ThriftTagType = Jaeger.Thrift.TagType;
 
 namespace Jaeger.Tests.Reporters.Protocols
 {
-    public class JaegerThriftSpanConverterTest
+    public class JaegerThriftSpanConverterTests
     {
         private static readonly ThriftReferenceComparer _thriftReferenceComparer = new ThriftReferenceComparer();
 
         private readonly Tracer _tracer;
 
-        public JaegerThriftSpanConverterTest()
+        public JaegerThriftSpanConverterTests()
         {
             _tracer = new Tracer.Builder("test-service-name")
                 .WithReporter(new InMemoryReporter())

--- a/test/Jaeger.Tests/Reporters/RemoteReporterTests.cs
+++ b/test/Jaeger.Tests/Reporters/RemoteReporterTests.cs
@@ -100,9 +100,9 @@ namespace Jaeger.Tests.Reporters
             Assert.Empty(_sender.GetAppended());
             Assert.Equal(numberOfSpans, _sender.GetFlushed().Count);
 
-            Assert.Equal(100, _metricsFactory.GetCounter("jaeger:started_spans", "sampled=y"));
-            Assert.Equal(100, _metricsFactory.GetCounter("jaeger:reporter_spans", "result=ok"));
-            Assert.Equal(100, _metricsFactory.GetCounter("jaeger:traces", "sampled=y,state=started"));
+            Assert.Equal(numberOfSpans, _metricsFactory.GetCounter("jaeger:started_spans", "sampled=y"));
+            Assert.Equal(numberOfSpans, _metricsFactory.GetCounter("jaeger:reporter_spans", "result=ok"));
+            Assert.Equal(numberOfSpans, _metricsFactory.GetCounter("jaeger:traces", "sampled=y,state=started"));
         }
 
         [Fact(Skip = "This test is flaky and deadlocks from time to time. May a smarter person fix it.")]

--- a/test/Jaeger.Tests/SpanIdTests.cs
+++ b/test/Jaeger.Tests/SpanIdTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Jaeger.Util;
 using Xunit;
 
 namespace Jaeger.Tests
@@ -25,6 +26,20 @@ namespace Jaeger.Tests
         {
             var longValue = (long)_spanId;
             Assert.Equal(longValue, Convert.ToInt64(_spanIdValue));
+        }
+
+        [Fact]
+        public void Field_ShouldReturnBytes()
+        {
+            Assert.Collection(_spanId.ToByteArray(),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x2a));
         }
     }
 }

--- a/test/Jaeger.Tests/TraceIdTests.cs
+++ b/test/Jaeger.Tests/TraceIdTests.cs
@@ -64,5 +64,51 @@ namespace Jaeger.Tests
             Assert.Equal("1", traceId.High.ToString());
             Assert.Equal("1", traceId.Low.ToString());
         }
+
+        [Fact]
+        public void TraceId_InitLow_ShouldReturnBytes()
+        {
+            var traceId = TraceId.FromString("fedcba9876543210");
+            Assert.Collection(traceId.ToByteArray(),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0x00),
+                b => Assert.Equal(b, (byte)0xfe),
+                b => Assert.Equal(b, (byte)0xdc),
+                b => Assert.Equal(b, (byte)0xba),
+                b => Assert.Equal(b, (byte)0x98),
+                b => Assert.Equal(b, (byte)0x76),
+                b => Assert.Equal(b, (byte)0x54),
+                b => Assert.Equal(b, (byte)0x32),
+                b => Assert.Equal(b, (byte)0x10));
+        }
+
+        [Fact]
+        public void TraceId_InitHighLow_ShouldReturnBytes()
+        {
+            var traceId = TraceId.FromString("0123456789abcdeffedcba9876543210");
+            Assert.Collection(traceId.ToByteArray(),
+                b => Assert.Equal(b, (byte)0x01),
+                b => Assert.Equal(b, (byte)0x23),
+                b => Assert.Equal(b, (byte)0x45),
+                b => Assert.Equal(b, (byte)0x67),
+                b => Assert.Equal(b, (byte)0x89),
+                b => Assert.Equal(b, (byte)0xab),
+                b => Assert.Equal(b, (byte)0xcd),
+                b => Assert.Equal(b, (byte)0xef),
+                b => Assert.Equal(b, (byte)0xfe),
+                b => Assert.Equal(b, (byte)0xdc),
+                b => Assert.Equal(b, (byte)0xba),
+                b => Assert.Equal(b, (byte)0x98),
+                b => Assert.Equal(b, (byte)0x76),
+                b => Assert.Equal(b, (byte)0x54),
+                b => Assert.Equal(b, (byte)0x32),
+                b => Assert.Equal(b, (byte)0x10));
+        }
     }
 }

--- a/test/Jaeger.Tests/UtilsTests.cs
+++ b/test/Jaeger.Tests/UtilsTests.cs
@@ -41,5 +41,19 @@ namespace Jaeger.Tests
         {
             Assert.Equal(-1, Utils.IpToInt("255.255.255.255"));
         }
+
+        [Fact]
+        public void TestLongToNetworkBytes()
+        {
+            Assert.Collection(Utils.LongToNetworkBytes(unchecked((long)0xC96C5795D7870F42)),
+                b => Assert.Equal(b, (byte)0xC9),
+                b => Assert.Equal(b, (byte)0x6C),
+                b => Assert.Equal(b, (byte)0x57),
+                b => Assert.Equal(b, (byte)0x95),
+                b => Assert.Equal(b, (byte)0xD7),
+                b => Assert.Equal(b, (byte)0x87),
+                b => Assert.Equal(b, (byte)0x0F),
+                b => Assert.Equal(b, (byte)0x42));
+        }
     }
 }


### PR DESCRIPTION
## Which problem is this PR solving?
-  Fixes #139

## Short description of the changes
- The jaeger-collector got an GRPC endpoint. This can be used instead of `Thrift`. This add a separate package `Jaeger.Grpc` (like `Jaeger.Thrift`).

As discussed in #116, we should invert the dependecy before releasing 0.4.0 so that the user can choose between `Thrift` or `Grpc` and does not have to get all the dependencies (or non in case they implement `ISender` themselves). But this is outside the scope of this PR.