### PR TITLE
Extending the range of supported versions of newtonsoft

### DIFF
--- a/src/Jaeger/Jaeger.csproj
+++ b/src/Jaeger/Jaeger.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="OpenTracing" Version="0.12.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Which problem is this PR solving? 
- Added support for projects which depends on old Newtonsoft Json library

## Short description of the changes
- Now depended on Newtonsoft.Json 9.0.1 and above