### PR TITLE
Ignore Jaeger internal traces in HttpSender (#154)

### DIFF
--- a/src/Jaeger/Senders/HttpSender.cs
+++ b/src/Jaeger/Senders/HttpSender.cs
@@ -45,7 +45,14 @@ namespace Jaeger.Senders
                 customHeaders.Add("Authorization", builder.AuthenticationHeaderValue.ToString());
             }
 
-            _transport = new THttpClientTransport(collectorUri, customHeaders);
+            var customProperties = new Dictionary<string, object>
+            {
+                // Note: This ensures that internal requests from the tracer are not instrumented
+                // by https://github.com/opentracing-contrib/csharp-netcore
+                { "ot-ignore", true }
+            };
+
+            _transport = new THttpClientTransport(collectorUri, customHeaders, customProperties);
             _protocol = ProtocolFactory.GetProtocol(_transport);
         }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves #154 

## Short description of the changes
Mark Jaeger client internal requests made by HttpSender with "ot-ignore" property which prevents requests from being instrumented by OpenTracing.Contrib.NetCore package.