### PR TITLE
Default SamplingManager set to HttpSamplingManager

### DIFF
--- a/src/Jaeger/Samplers/RemoteControlledSampler.cs
+++ b/src/Jaeger/Samplers/RemoteControlledSampler.cs
@@ -208,6 +208,10 @@ namespace Jaeger.Samplers
                 {
                     Metrics = new MetricsImpl(NoopMetricsFactory.Instance);
                 }
+                if (SamplingManager == null)
+                {
+                    SamplingManager = new HttpSamplingManager();
+                }
                 return new RemoteControlledSampler(this);
             }
         }

--- a/test/Jaeger.Tests/Samplers/RemoteControlledSamplerTests.cs
+++ b/test/Jaeger.Tests/Samplers/RemoteControlledSamplerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using NSubstitute.Extensions;
 using Xunit;
 
 namespace Jaeger.Tests.Samplers
@@ -154,6 +155,18 @@ namespace Jaeger.Tests.Samplers
                 .Build();
 
             Assert.Equal(new ProbabilisticSampler(0.001), _undertest.Sampler);
+        }
+
+        [Fact]
+        public void BuilderDefaultSamplingManagerIsSetToHttpSamplingManager()
+        {
+            var builder = new RemoteControlledSampler
+                .Builder(SERVICE_NAME);
+
+            builder.Build();
+
+            Assert.NotNull(builder.SamplingManager);
+            Assert.Equal(typeof(HttpSamplingManager), builder.SamplingManager.GetType());            
         }
     }
 }


### PR DESCRIPTION
Default SamplingManager is set to HttpSamplingManager.

https://github.com/jaegertracing/jaeger-client-csharp/tree/master/src/Jaeger/Samplers#remote-controlled-sampler

## Which problem is this PR solving?
Even default sampler is RemoteControlledSampler it doesn't have default SamplingManager as it mentioned in documentation that's why this situation produce an exeption during execution.

## Short description of the changes
Added default SamplingManager, added one unit test.
