### PR TITLE
JAEGER_AGENT_HOST sets the default for RemoteControlledSampler host

### DIFF
--- a/src/Jaeger/Configuration.cs
+++ b/src/Jaeger/Configuration.cs
@@ -315,6 +315,11 @@ namespace Jaeger
             /// Optional.
             /// </summary>
             public string ManagerHostPort { get; private set; }
+            
+            /// <summary>
+            /// HTTP host fallback if ManagerHostPort is not set.
+            /// </summary>
+            private string FallbackManagerHost { get; set; }
 
             public SamplerConfiguration(ILoggerFactory loggerFactory)
             {
@@ -331,7 +336,8 @@ namespace Jaeger
                 return new SamplerConfiguration(loggerFactory)
                     .WithType(GetProperty(JaegerSamplerType, configuration))
                     .WithParam(GetPropertyAsDouble(JaegerSamplerParam, logger, configuration))
-                    .WithManagerHostPort(GetProperty(JaegerSamplerManagerHostPort, configuration));
+                    .WithManagerHostPort(GetProperty(JaegerSamplerManagerHostPort, configuration))
+                    .WithFallbackManagerHost(GetProperty(JaegerAgentHost, configuration));
             }
 
             /// <summary>
@@ -349,7 +355,8 @@ namespace Jaeger
             {
                 string samplerType = StringOrDefault(Type, RemoteControlledSampler.Type);
                 double samplerParam = Param.GetValueOrDefault(ProbabilisticSampler.DefaultSamplingProbability);
-                string hostPort = StringOrDefault(ManagerHostPort, HttpSamplingManager.DefaultHostPort);
+                string fallbackHost = StringOrDefault(FallbackManagerHost, HttpSamplingManager.DefaultHost);
+                string hostPort = StringOrDefault(ManagerHostPort, $"{fallbackHost}:{HttpSamplingManager.DefaultPort}");
 
                 switch (samplerType)
                 {
@@ -386,6 +393,12 @@ namespace Jaeger
             public SamplerConfiguration WithManagerHostPort(string managerHostPort)
             {
                 ManagerHostPort = managerHostPort;
+                return this;
+            }
+
+            private SamplerConfiguration WithFallbackManagerHost(string managerHost)
+            {
+                FallbackManagerHost = managerHost;
                 return this;
             }
         }

--- a/src/Jaeger/Samplers/HttpSamplingManager.cs
+++ b/src/Jaeger/Samplers/HttpSamplingManager.cs
@@ -8,7 +8,9 @@ namespace Jaeger.Samplers
 {
     public class HttpSamplingManager : ISamplingManager
     {
-        public const string DefaultHostPort = "localhost:5778";
+        public const string DefaultHost = "localhost";
+        public const string DefaultPort = "5778";
+        public const string DefaultHostPort = DefaultHost + ":" + DefaultPort;
 
         private readonly IHttpClient _httpClient;
         private readonly string _hostPort;

--- a/test/Jaeger.Tests/ConfigurationTests.cs
+++ b/test/Jaeger.Tests/ConfigurationTests.cs
@@ -527,6 +527,16 @@ namespace Jaeger.Tests
             Assert.True(sampler is RateLimitingSampler);
         }
 
+        [Fact]
+        public void TestRemoteControlledSampler()
+        {
+            SamplerConfiguration samplerConfiguration = new SamplerConfiguration(_loggerFactory)
+                .WithType(RemoteControlledSampler.Type);
+            ISampler sampler = samplerConfiguration.GetSampler("name",
+                new MetricsImpl(NoopMetricsFactory.Instance));
+            Assert.True(sampler is RemoteControlledSampler);
+        }
+
         internal class TestTextMap : ITextMap
         {
             private Dictionary<string, string> _values = new Dictionary<string, string>();


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #163

## Short description of the changes
Up until now, `JAEGER_AGENT_HOST` and `JAEGER_SAMPLER_MANAGER_HOST_PORT` were completely separate. Usually, the user wants `JAEGER_AGENT_HOST` to set the default host for `JAEGER_SAMPLER_MANAGER_HOST_PORT` if undefined (which is the regular case).

@yurishkuro How is this handled in other implementations? Is `JAEGER_SAMPLER_MANAGER_HOST_PORT` necessary to be set i.E. to `jaeger-agent:5778` if `JAEGER_AGENT_HOST` is set to `jaeger-agent` or is this done implicitly?