### PR TITLE
Replace JAEGER_SAMPLER_MANAGER_HOST_PORT with JAEGER_SAMPLING_ENDPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ JAEGER_REPORTER_MAX_QUEUE_SIZE | no | The reporter's maximum queue size
 JAEGER_REPORTER_FLUSH_INTERVAL | no | The reporter's flush interval (ms)
 JAEGER_SAMPLER_TYPE | no | The sampler type
 JAEGER_SAMPLER_PARAM | no | The sampler parameter (double)
+JAEGER_SAMPLER_MANAGER_HOST_PORT | no | (DEPRECATED) The host name and port when using the remote controlled sampler
 JAEGER_SAMPLING_ENDPOINT | no | The url for the remote sampling conf when using sampler type remote. Default is http://127.0.0.1:5778/sampling
 JAEGER_TAGS | no | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found
 JAEGER_TRACEID_128BIT | no | Whether to use 128bit TraceID instead of 64bit

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ JAEGER_REPORTER_LOG_SPANS | no | Whether the reporter should also log the spans
 JAEGER_REPORTER_MAX_QUEUE_SIZE | no | The reporter's maximum queue size
 JAEGER_REPORTER_FLUSH_INTERVAL | no | The reporter's flush interval (ms)
 JAEGER_SAMPLER_TYPE | no | The sampler type
-JAEGER_SAMPLER_PARAM | no | The sampler parameter (number)
-JAEGER_SAMPLER_MANAGER_HOST_PORT | no | The host name and port when using the remote controlled sampler
+JAEGER_SAMPLER_PARAM | no | The sampler parameter (double)
+JAEGER_SAMPLING_ENDPOINT | no | The url for the remote sampling conf when using sampler type remote. Default is http://127.0.0.1:5778/sampling
 JAEGER_TAGS | no | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found
 JAEGER_TRACEID_128BIT | no | Whether to use 128bit TraceID instead of 64bit
 

--- a/src/Jaeger/Configuration.cs
+++ b/src/Jaeger/Configuration.cs
@@ -83,6 +83,11 @@ namespace Jaeger
         public const string JaegerSamplerParam = JaegerPrefix + "SAMPLER_PARAM";
 
         /// <summary>
+        /// The sampler manager host:port.
+        /// </summary>
+        public const string JaegerSamplerManagerHostPort = JaegerPrefix + "SAMPLER_MANAGER_HOST_PORT";
+
+        /// <summary>
         /// The url for the remote sampling conf when using sampler type remote.
         /// </summary>
         public const string JaegerSamplingEndpoint = JaegerPrefix + "SAMPLING_ENDPOINT";
@@ -161,7 +166,7 @@ namespace Jaeger
         {
             ILogger logger = loggerFactory.CreateLogger<Configuration>();
 
-            return new Configuration(GetProperty(JaegerServiceName, configuration), loggerFactory)
+            return new Configuration(GetProperty(JaegerServiceName, logger, configuration), loggerFactory)
                 .WithTracerTags(TracerTagsFromIConfiguration(logger, configuration))
                 .WithTraceId128Bit(GetPropertyAsBool(JaegerTraceId128Bit, logger, configuration).GetValueOrDefault(false))
                 .WithReporter(ReporterConfiguration.FromIConfiguration(loggerFactory, configuration))
@@ -311,6 +316,12 @@ namespace Jaeger
             public double? Param { get; private set; }
 
             /// <summary>
+            /// HTTP host:port of the sampling manager that can provide sampling strategy to this service.
+            /// </summary>
+            [Obsolete("Please use SamplingEndpoint instead!")]
+            public string ManagerHostPort { get; private set; }
+
+            /// <summary>
             /// The URL of the sampling manager that can provide sampling strategy to this service.
             /// Optional.
             /// </summary>
@@ -327,11 +338,14 @@ namespace Jaeger
             public static SamplerConfiguration FromIConfiguration(ILoggerFactory loggerFactory, IConfiguration configuration)
             {
                 ILogger logger = loggerFactory.CreateLogger<Configuration>();
-
+                
+#pragma warning disable CS0618 // Supress warning on obsolete method: WithManagerHostPort
                 return new SamplerConfiguration(loggerFactory)
-                    .WithType(GetProperty(JaegerSamplerType, configuration))
+                    .WithType(GetProperty(JaegerSamplerType, logger, configuration))
                     .WithParam(GetPropertyAsDouble(JaegerSamplerParam, logger, configuration))
-                    .WithSamplingEndpoint(GetProperty(JaegerSamplingEndpoint, configuration));
+                    .WithManagerHostPort(GetProperty(JaegerSamplerManagerHostPort, logger, configuration, JaegerSamplingEndpoint))
+                    .WithSamplingEndpoint(GetProperty(JaegerSamplingEndpoint, logger, configuration));
+#pragma warning restore CS0618 // Supress warning on obsolete method: WithManagerHostPort
             }
 
             /// <summary>
@@ -347,9 +361,12 @@ namespace Jaeger
 
             public virtual ISampler GetSampler(string serviceName, IMetrics metrics)
             {
+#pragma warning disable CS0618 // Supress warning on obsolete property: ManagerHostPort
                 string samplerType = StringOrDefault(Type, RemoteControlledSampler.Type);
                 double samplerParam = Param.GetValueOrDefault(ProbabilisticSampler.DefaultSamplingProbability);
-                string samplingEndpoint = StringOrDefault(SamplingEndpoint, HttpSamplingManager.DefaultEndpoint);
+                string hostPort = StringOrDefault(ManagerHostPort, HttpSamplingManager.DefaultHostPort);
+                string samplingEndpoint = StringOrDefault(SamplingEndpoint, "http://" + hostPort);
+#pragma warning disable CS0618 // Supress warning on obsolete property: ManagerHostPort
 
                 switch (samplerType)
                 {
@@ -383,6 +400,13 @@ namespace Jaeger
                 return this;
             }
 
+            [Obsolete("Use WithSamplingEndpoint instead!")]
+            public SamplerConfiguration WithManagerHostPort(string managerHostPort)
+            {
+                ManagerHostPort = managerHostPort;
+                return this;
+            }
+
             public SamplerConfiguration WithSamplingEndpoint(string samplingEndpoint)
             {
                 SamplingEndpoint = samplingEndpoint;
@@ -412,7 +436,7 @@ namespace Jaeger
                 ILogger logger = loggerFactory.CreateLogger<Configuration>();
 
                 CodecConfiguration codecConfiguration = new CodecConfiguration(loggerFactory);
-                string propagation = GetProperty(JaegerPropagation, configuration);
+                string propagation = GetProperty(JaegerPropagation, logger, configuration);
                 if (propagation != null)
                 {
                     foreach (string format in propagation.Split(','))
@@ -706,13 +730,13 @@ namespace Jaeger
             {
                 ILogger logger = loggerFactory.CreateLogger<Configuration>();
 
-                string agentHost = GetProperty(JaegerAgentHost, configuration);
+                string agentHost = GetProperty(JaegerAgentHost, logger, configuration);
                 int? agentPort = GetPropertyAsInt(JaegerAgentPort, logger, configuration);
 
-                string collectorEndpoint = GetProperty(JaegerEndpoint, configuration);
-                string authToken = GetProperty(JaegerAuthToken, configuration);
-                string authUsername = GetProperty(JaegerUser, configuration);
-                string authPassword = GetProperty(JaegerPassword, configuration);
+                string collectorEndpoint = GetProperty(JaegerEndpoint, logger, configuration);
+                string authToken = GetProperty(JaegerAuthToken, logger, configuration);
+                string authUsername = GetProperty(JaegerUser, logger, configuration);
+                string authPassword = GetProperty(JaegerPassword, logger, configuration);
 
                 return new SenderConfiguration(loggerFactory)
                     .WithAgentHost(agentHost)
@@ -740,14 +764,20 @@ namespace Jaeger
             return value != null && value.Length > 0 ? value : defaultValue;
         }
 
-        private static string GetProperty(string name, IConfiguration configuration)
+        private static string GetProperty(string name, ILogger logger, IConfiguration configuration, string replacedBy = null)
         {
-            return configuration[name];
+            var value = configuration[name];
+            if (replacedBy != null && value != null)
+            {
+                logger.LogWarning($"The entry {name} is obsolete. Use {replacedBy} instead!");
+            }
+
+            return value;
         }
 
         private static int? GetPropertyAsInt(string name, ILogger logger, IConfiguration configuration)
         {
-            string value = GetProperty(name, configuration);
+            string value = GetProperty(name, logger, configuration);
             if (!string.IsNullOrEmpty(value))
             {
                 if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int intValue))
@@ -764,7 +794,7 @@ namespace Jaeger
 
         private static double? GetPropertyAsDouble(string name, ILogger logger, IConfiguration configuration)
         {
-            string value = GetProperty(name, configuration);
+            string value = GetProperty(name, logger, configuration);
             if (!string.IsNullOrEmpty(value))
             {
                 if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double doubleValue))
@@ -795,7 +825,7 @@ namespace Jaeger
         /// </summary>
         private static bool? GetPropertyAsBool(string name, ILogger logger, IConfiguration configuration)
         {
-            string value = GetProperty(name, configuration);
+            string value = GetProperty(name, logger, configuration);
             if (!string.IsNullOrEmpty(value))
             {
                 if (string.Equals(value, "1", StringComparison.Ordinal))
@@ -822,7 +852,7 @@ namespace Jaeger
         private static Dictionary<string, string> TracerTagsFromIConfiguration(ILogger logger, IConfiguration configuration)
         {
             Dictionary<string, string> tracerTagMaps = null;
-            string tracerTags = GetProperty(JaegerTags, configuration);
+            string tracerTags = GetProperty(JaegerTags, logger, configuration);
             if (!string.IsNullOrEmpty(tracerTags))
             {
                 string[] tags = tracerTags.Split(',');
@@ -835,7 +865,7 @@ namespace Jaeger
                         {
                             tracerTagMaps = new Dictionary<string, string>();
                         }
-                        tracerTagMaps[tagValue[0].Trim()] = ResolveValue(tagValue[1].Trim(), configuration);
+                        tracerTagMaps[tagValue[0].Trim()] = ResolveValue(tagValue[1].Trim(), logger, configuration);
                     }
                     else
                     {
@@ -846,14 +876,14 @@ namespace Jaeger
             return tracerTagMaps;
         }
 
-        private static string ResolveValue(string value, IConfiguration configuration)
+        private static string ResolveValue(string value, ILogger logger, IConfiguration configuration)
         {
             if (value.StartsWith("${") && value.EndsWith("}"))
             {
                 string[] kvp = value.Substring(2, value.Length - 3).Split(':');
                 if (kvp.Length > 0)
                 {
-                    string propertyValue = GetProperty(kvp[0].Trim(), configuration);
+                    string propertyValue = GetProperty(kvp[0].Trim(), logger, configuration);
                     if (propertyValue == null && kvp.Length > 1)
                     {
                         propertyValue = kvp[1].Trim();

--- a/src/Jaeger/Configuration.cs
+++ b/src/Jaeger/Configuration.cs
@@ -83,9 +83,9 @@ namespace Jaeger
         public const string JaegerSamplerParam = JaegerPrefix + "SAMPLER_PARAM";
 
         /// <summary>
-        /// The sampler manager host:port.
+        /// The url for the remote sampling conf when using sampler type remote.
         /// </summary>
-        public const string JaegerSamplerManagerHostPort = JaegerPrefix + "SAMPLER_MANAGER_HOST_PORT";
+        public const string JaegerSamplingEndpoint = JaegerPrefix + "SAMPLING_ENDPOINT";
 
         /// <summary>
         /// The service name.
@@ -311,10 +311,10 @@ namespace Jaeger
             public double? Param { get; private set; }
 
             /// <summary>
-            /// HTTP host:port of the sampling manager that can provide sampling strategy to this service.
+            /// The URL of the sampling manager that can provide sampling strategy to this service.
             /// Optional.
             /// </summary>
-            public string ManagerHostPort { get; private set; }
+            public string SamplingEndpoint { get; private set; }
 
             public SamplerConfiguration(ILoggerFactory loggerFactory)
             {
@@ -331,7 +331,7 @@ namespace Jaeger
                 return new SamplerConfiguration(loggerFactory)
                     .WithType(GetProperty(JaegerSamplerType, configuration))
                     .WithParam(GetPropertyAsDouble(JaegerSamplerParam, logger, configuration))
-                    .WithManagerHostPort(GetProperty(JaegerSamplerManagerHostPort, configuration));
+                    .WithSamplingEndpoint(GetProperty(JaegerSamplingEndpoint, configuration));
             }
 
             /// <summary>
@@ -349,7 +349,7 @@ namespace Jaeger
             {
                 string samplerType = StringOrDefault(Type, RemoteControlledSampler.Type);
                 double samplerParam = Param.GetValueOrDefault(ProbabilisticSampler.DefaultSamplingProbability);
-                string hostPort = StringOrDefault(ManagerHostPort, HttpSamplingManager.DefaultHostPort);
+                string samplingEndpoint = StringOrDefault(SamplingEndpoint, HttpSamplingManager.DefaultEndpoint);
 
                 switch (samplerType)
                 {
@@ -362,7 +362,7 @@ namespace Jaeger
                     case RemoteControlledSampler.Type:
                         return new RemoteControlledSampler.Builder(serviceName)
                             .WithLoggerFactory(_loggerFactory)
-                            .WithSamplingManager(new HttpSamplingManager(hostPort))
+                            .WithSamplingManager(new HttpSamplingManager(samplingEndpoint))
                             .WithInitialSampler(new ProbabilisticSampler(samplerParam))
                             .WithMetrics(metrics)
                             .Build();
@@ -383,9 +383,9 @@ namespace Jaeger
                 return this;
             }
 
-            public SamplerConfiguration WithManagerHostPort(string managerHostPort)
+            public SamplerConfiguration WithSamplingEndpoint(string samplingEndpoint)
             {
-                ManagerHostPort = managerHostPort;
+                SamplingEndpoint = samplingEndpoint;
                 return this;
             }
         }

--- a/src/Jaeger/Samplers/HttpSamplingManager.cs
+++ b/src/Jaeger/Samplers/HttpSamplingManager.cs
@@ -8,7 +8,8 @@ namespace Jaeger.Samplers
 {
     public class HttpSamplingManager : ISamplingManager
     {
-        public const string DefaultEndpoint = "http://127.0.0.1:5778/sampling";
+        public const string DefaultHostPort = "127.0.0.1:5778";
+        public const string DefaultEndpoint = "http://" + DefaultHostPort + "/sampling";
 
         private readonly IHttpClient _httpClient;
         private readonly string _endpoint;
@@ -22,6 +23,13 @@ namespace Jaeger.Samplers
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _endpoint = endpoint ?? DefaultEndpoint;
+
+            // Workaround for obsolete HostPort notation.
+            // UriBuilder needs the schema if host is not an IP and port is given:
+            if (!_endpoint.StartsWith("http://") && !_endpoint.StartsWith("https://"))
+            {
+                _endpoint = "http://" + _endpoint;
+            }
         }
 
         internal SamplingStrategyResponse ParseJson(string json)

--- a/src/Jaeger/Samplers/HttpSamplingManager.cs
+++ b/src/Jaeger/Samplers/HttpSamplingManager.cs
@@ -8,20 +8,20 @@ namespace Jaeger.Samplers
 {
     public class HttpSamplingManager : ISamplingManager
     {
-        public const string DefaultHostPort = "localhost:5778";
+        public const string DefaultEndpoint = "http://127.0.0.1:5778/sampling";
 
         private readonly IHttpClient _httpClient;
-        private readonly string _hostPort;
+        private readonly string _endpoint;
 
-        public HttpSamplingManager(string hostPort = DefaultHostPort)
-            : this(new DefaultHttpClient(), hostPort)
+        public HttpSamplingManager(string endpoint = DefaultEndpoint)
+            : this(new DefaultHttpClient(), endpoint)
         {
         }
 
-        public HttpSamplingManager(IHttpClient httpClient, string hostPort = DefaultHostPort)
+        public HttpSamplingManager(IHttpClient httpClient, string endpoint = DefaultEndpoint)
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-            _hostPort = hostPort ?? DefaultHostPort;
+            _endpoint = endpoint ?? DefaultEndpoint;
         }
 
         internal SamplingStrategyResponse ParseJson(string json)
@@ -31,15 +31,15 @@ namespace Jaeger.Samplers
 
         public async Task<SamplingStrategyResponse> GetSamplingStrategyAsync(string serviceName)
         {
-            string url = "http://" + _hostPort + "/?service=" + Uri.EscapeDataString(serviceName);
-            string jsonString = await _httpClient.MakeGetRequestAsync(url).ConfigureAwait(false);
+            Uri uri = new UriBuilder(_endpoint) {Query = "service=" + Uri.EscapeDataString(serviceName)}.Uri;
+            string jsonString = await _httpClient.MakeGetRequestAsync(uri.AbsoluteUri).ConfigureAwait(false);
 
             return ParseJson(jsonString);
         }
 
         public override string ToString()
         {
-            return $"{nameof(HttpSamplingManager)}(HostPort={_hostPort})";
+            return $"{nameof(HttpSamplingManager)}(Endpoint={_endpoint})";
         }
     }
 }

--- a/test/Jaeger.Tests/ConfigurationTests.cs
+++ b/test/Jaeger.Tests/ConfigurationTests.cs
@@ -8,9 +8,12 @@ using System.Threading.Tasks;
 using Jaeger.Metrics;
 using Jaeger.Samplers;
 using Jaeger.Senders;
+using Jaeger.Util;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using NSubstitute.ReceivedExtensions;
 using OpenTracing;
 using OpenTracing.Noop;
 using OpenTracing.Propagation;
@@ -48,6 +51,7 @@ namespace Jaeger.Tests
             ClearProperty(Configuration.JaegerReporterFlushInterval);
             ClearProperty(Configuration.JaegerSamplerType);
             ClearProperty(Configuration.JaegerSamplerParam);
+            ClearProperty(Configuration.JaegerSamplerManagerHostPort);
             ClearProperty(Configuration.JaegerSamplingEndpoint);
             ClearProperty(Configuration.JaegerServiceName);
             ClearProperty(Configuration.JaegerTags);
@@ -525,6 +529,22 @@ namespace Jaeger.Tests
             ISampler sampler = samplerConfiguration.GetSampler("name",
                 new MetricsImpl(NoopMetricsFactory.Instance));
             Assert.True(sampler is RateLimitingSampler);
+        }
+
+        [Fact]
+        public void TestDeprecatedSamplerManagerHostPort()
+        {
+            ILoggerFactory loggerFactory = Substitute.For<ILoggerFactory>();
+            ILogger logger = Substitute.For<ILogger>();
+            loggerFactory.CreateLogger<Configuration>().Returns(logger);
+
+            SetProperty(Configuration.JaegerSamplerManagerHostPort, HttpSamplingManager.DefaultHostPort);
+            SamplerConfiguration samplerConfiguration = SamplerConfiguration.FromEnv(loggerFactory);
+            ISampler sampler = samplerConfiguration.GetSampler("name",
+                new MetricsImpl(NoopMetricsFactory.Instance));
+            Assert.True(sampler is RemoteControlledSampler);
+            loggerFactory.Received(1).CreateLogger<Configuration>();
+            logger.Received(1).Log(LogLevel.Warning, Arg.Any<EventId>(), Arg.Any<object>(), null, Arg.Any<Func<object, Exception, string>>());
         }
 
         internal class TestTextMap : ITextMap

--- a/test/Jaeger.Tests/ConfigurationTests.cs
+++ b/test/Jaeger.Tests/ConfigurationTests.cs
@@ -48,7 +48,7 @@ namespace Jaeger.Tests
             ClearProperty(Configuration.JaegerReporterFlushInterval);
             ClearProperty(Configuration.JaegerSamplerType);
             ClearProperty(Configuration.JaegerSamplerParam);
-            ClearProperty(Configuration.JaegerSamplerManagerHostPort);
+            ClearProperty(Configuration.JaegerSamplingEndpoint);
             ClearProperty(Configuration.JaegerServiceName);
             ClearProperty(Configuration.JaegerTags);
             ClearProperty(Configuration.JaegerTraceId128Bit);

--- a/test/Jaeger.Tests/Samplers/HttpSamplingManagerTests.cs
+++ b/test/Jaeger.Tests/Samplers/HttpSamplingManagerTests.cs
@@ -30,7 +30,7 @@ namespace Jaeger.Tests.Samplers
         {
             var instance = new HttpSamplingManager(_httpClient, "example.com:80");
             _httpClient.MakeGetRequestAsync("http://example.com/?service=clairvoyant")
-                .Returns("{\"strategyType\":0,\"probabilisticSampling\":{\"samplingRate\":0.001},\"rateLimitingSampling\":null}");
+                .Returns("{\"strategyType\":\"PROBABILISTIC\",\"probabilisticSampling\":{\"samplingRate\":0.001},\"rateLimitingSampling\":null}");
 
             SamplingStrategyResponse response = await instance.GetSamplingStrategyAsync("clairvoyant");
             Assert.NotNull(response.ProbabilisticSampling);
@@ -40,7 +40,7 @@ namespace Jaeger.Tests.Samplers
         public async Task TestGetSamplingStrategy()
         {
             _httpClient.MakeGetRequestAsync("http://www.example.com/sampling?service=clairvoyant")
-               .Returns("{\"strategyType\":0,\"probabilisticSampling\":{\"samplingRate\":0.001},\"rateLimitingSampling\":null}");
+               .Returns("{\"strategyType\":\"PROBABILISTIC\",\"probabilisticSampling\":{\"samplingRate\":0.001},\"rateLimitingSampling\":null}");
 
             SamplingStrategyResponse response = await _undertest.GetSamplingStrategyAsync("clairvoyant");
             Assert.NotNull(response.ProbabilisticSampling);

--- a/test/Jaeger.Tests/Samplers/HttpSamplingManagerTests.cs
+++ b/test/Jaeger.Tests/Samplers/HttpSamplingManagerTests.cs
@@ -22,13 +22,24 @@ namespace Jaeger.Tests.Samplers
         public HttpSamplingManagerTests()
         {
             _httpClient = Substitute.For<IHttpClient>();
-            _undertest = new HttpSamplingManager(_httpClient, "http://www.example.com");
+            _undertest = new HttpSamplingManager(_httpClient, "http://www.example.com/sampling");
+        }
+
+        [Fact]
+        public async Task TestAllowHostPortSyntax()
+        {
+            var instance = new HttpSamplingManager(_httpClient, "example.com:80");
+            _httpClient.MakeGetRequestAsync("http://example.com/?service=clairvoyant")
+                .Returns("{\"strategyType\":0,\"probabilisticSampling\":{\"samplingRate\":0.001},\"rateLimitingSampling\":null}");
+
+            SamplingStrategyResponse response = await instance.GetSamplingStrategyAsync("clairvoyant");
+            Assert.NotNull(response.ProbabilisticSampling);
         }
 
         [Fact]
         public async Task TestGetSamplingStrategy()
         {
-            _httpClient.MakeGetRequestAsync("http://www.example.com/?service=clairvoyant")
+            _httpClient.MakeGetRequestAsync("http://www.example.com/sampling?service=clairvoyant")
                .Returns("{\"strategyType\":0,\"probabilisticSampling\":{\"samplingRate\":0.001},\"rateLimitingSampling\":null}");
 
             SamplingStrategyResponse response = await _undertest.GetSamplingStrategyAsync("clairvoyant");
@@ -38,7 +49,7 @@ namespace Jaeger.Tests.Samplers
         [Fact]
         public async Task TestGetSamplingStrategyError()
         {
-            _httpClient.MakeGetRequestAsync("http://www.example.com/?service=")
+            _httpClient.MakeGetRequestAsync("http://www.example.com/sampling?service=")
                 .Returns(new Func<CallInfo, string>(_ => { throw new InvalidOperationException(); }));
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => _undertest.GetSamplingStrategyAsync(""));

--- a/test/Jaeger.Tests/Samplers/HttpSamplingManagerTests.cs
+++ b/test/Jaeger.Tests/Samplers/HttpSamplingManagerTests.cs
@@ -22,7 +22,7 @@ namespace Jaeger.Tests.Samplers
         public HttpSamplingManagerTests()
         {
             _httpClient = Substitute.For<IHttpClient>();
-            _undertest = new HttpSamplingManager(_httpClient, "www.example.com");
+            _undertest = new HttpSamplingManager(_httpClient, "http://www.example.com");
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace Jaeger.Tests.Samplers
         [Fact]
         public async Task TestDefaultConstructor()
         {
-            _httpClient.MakeGetRequestAsync("http://localhost:5778/?service=name")
+            _httpClient.MakeGetRequestAsync("http://127.0.0.1:5778/sampling?service=name")
                 .Returns(new Func<CallInfo, string>(_ => { throw new InvalidOperationException(); }));
 
             HttpSamplingManager httpSamplingManager = new HttpSamplingManager(_httpClient);

--- a/test/Jaeger.Tests/Samplers/Resources/per_operation_sampling.json
+++ b/test/Jaeger.Tests/Samplers/Resources/per_operation_sampling.json
@@ -21,5 +21,5 @@
     "samplingRate": 0.001
   },
   "rateLimitingSampling": null,
-  "strategyType": 0
+  "strategyType": "PROBABILISTIC"
 }

--- a/test/Jaeger.Tests/Samplers/Resources/probabilistic_sampling.json
+++ b/test/Jaeger.Tests/Samplers/Resources/probabilistic_sampling.json
@@ -1,7 +1,7 @@
 {
-  "strategyType": 0,
-  "probabilisticSampling": {
-    "samplingRate": 0.01
-  },
-  "rateLimitingSampling": null
+    "strategyType": "PROBABILISTIC",
+    "probabilisticSampling": {
+        "samplingRate": 0.01
+    },
+    "rateLimitingSampling": null
 }

--- a/test/Jaeger.Tests/Samplers/Resources/ratelimiting_sampling.json
+++ b/test/Jaeger.Tests/Samplers/Resources/ratelimiting_sampling.json
@@ -1,7 +1,7 @@
 {
-  "strategyType": 1,
-  "probabilisticSampling": null,
-  "rateLimitingSampling": {
-    "maxTracesPerSecond": 2.1
-  }
+    "strategyType": "RATE_LIMITING",
+    "probabilisticSampling": null,
+    "rateLimitingSampling": {
+        "maxTracesPerSecond": 2.1
+    }
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Implements https://github.com/jaegertracing/jaeger/issues/1849
- Fixes https://github.com/jaegertracing/jaeger-client-csharp/issues/163

## Short description of the changes
- JAEGER_SAMPLER_MANAGER_HOST_PORT was changed to JAEGER_SAMPLING_ENDPOINT and contains a base uri now instead of host:port