### PR TITLE
[Thrift] HttpClientHandler.ClientCertificates MissingMethodException

### DIFF
--- a/src/Thrift/netcore/Thrift/Transports/Client/THttpClientTransport.cs
+++ b/src/Thrift/netcore/Thrift/Transports/Client/THttpClientTransport.cs
@@ -147,12 +147,23 @@ namespace Thrift.Transports.Client
             await _outputStream.WriteAsync(buffer, offset, length, cancellationToken);
         }
 
+        /// <summary>
+        /// Seperate function to avoid a MissingMethodException in .NET Framework 4.6.1
+        /// https://stackoverflow.com/a/46577035/10038915
+        /// Related to: https://github.com/jaegertracing/jaeger-client-csharp/issues/105
+        /// </summary>
+        /// <param name="handler">HttpClientHandler</param>
+        private void AddCertificates(HttpClientHandler handler)
+        {
+            handler.ClientCertificates.AddRange(_certificates);
+        }
+
         private HttpClient CreateClient()
         {
             var handler = new HttpClientHandler();
             if (_certificates.Length > 0)
             {
-                handler.ClientCertificates.AddRange(_certificates);
+                AddCertificates(handler);
             }
 
             var httpClient = new HttpClient(handler);


### PR DESCRIPTION
This is an addition to the issue #105.
Seperated the call of handler.ClientCertificates.AddRange() to a single function.
Some APIs are not implemented in net461/net462, but they are available in
netStandard2.0, see: https://stackoverflow.com/a/46577035/10038915
Signed-off-by: Jonas S. j@tkaj.de

## Which problem is this PR solving?
- Resolves #105 

## Short description of the changes
- The additional "if-clause" does not solve the problem completely. Probably the just-in-time compiler tries to access the ClientCertificates property and so the exception gets thrown. I seperated the call of the not implemented property (eg. in .NET 4.6.1) to a single function to avoid the exception at JIT time.