### PR TITLE
Initialize Random Harder

### DIFF
--- a/src/Jaeger.Core/Util/Utils.cs
+++ b/src/Jaeger.Core/Util/Utils.cs
@@ -1,11 +1,24 @@
 using System;
 using System.Net;
+using System.Security.Cryptography;
 
 namespace Jaeger.Util
 {
     public static class Utils
     {
-        private static readonly Random Random = new Random();
+        private static readonly Random Random;
+
+        static Utils()
+        {
+            // Really initialize the random number generator so that multiple processes
+            // starting at the same time do not duplicate IDs.
+            using ( RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider() )
+            {
+                byte[] bytes = new byte[4];
+                rngCsp.GetBytes(bytes);
+                Random = new Random(BitConverter.ToInt32(bytes, 0));
+            }
+        }
 
         public static int IpToInt(string ipAddress)
         {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Resolves #177

## Short description of the changes
Fix for duplicate IDs from multiple processes started at the same time. Use a cryptographic
random number generator instead of current time to seed Random.

This can be used instead of or as well as #179, they do not conflict. This commit makes the default random number generation safe against multiple processes launching at the same time. I'm sure for most of your users this is quite unlikely as their processes tend to be long lived, and don't start very often. However, if it ever does happen it will be fatal. This random number generator is used for nothing else, so all trace and span IDs created by both processes will collide for the life of the processes.

Signed-off-by: phxnsharp <nsharp@phoenix-int.com>