### PR TITLE
async flush

### DIFF
--- a/src/Jaeger.Core/Reporters/RemoteReporter.cs
+++ b/src/Jaeger.Core/Reporters/RemoteReporter.cs
@@ -70,7 +70,7 @@ namespace Jaeger.Reporters
 
             if (_commandQueue.Count >= _maxQueueSize)
             {
-                var t = FlushAsync();
+                var t = FlushAsync(new CancellationTokenSource(10000).Token);
             }
 
         }
@@ -120,9 +120,9 @@ namespace Jaeger.Reporters
             }
         }
 
-        internal async Task FlushAsync()
+        internal async Task FlushAsync(CancellationToken token)
         {
-            await Task.Run(Flush);
+            await Task.Run(Flush, token);
         }
 
         internal void Flush()

--- a/test/Jaeger.Core.Tests/Reporters/RemoteReporterTests.cs
+++ b/test/Jaeger.Core.Tests/Reporters/RemoteReporterTests.cs
@@ -15,8 +15,10 @@ using Xunit.Abstractions;
 
 namespace Jaeger.Core.Tests.Reporters
 {
+    //
     public class RemoteReporterTests
     {
+
         private const int MaxQueueSize = 500;
         private readonly TimeSpan _flushInterval = TimeSpan.FromSeconds(1);
         private readonly TimeSpan _closeTimeout = TimeSpan.FromSeconds(1);

--- a/test/Jaeger.Core.Tests/Reporters/RemoteReporterTests.cs
+++ b/test/Jaeger.Core.Tests/Reporters/RemoteReporterTests.cs
@@ -82,7 +82,7 @@ namespace Jaeger.Core.Tests.Reporters
             Assert.Single(received);
         }
 
-        [Fact]
+        [Fact] 
         public async Task TestRemoteReporterFlushesOnClose()
         {
             SetupTracer();


### PR DESCRIPTION
# Which problem is this PR solving?
- fix #193 (It is possible that in some cases we reach the maximum number of block items and can no longer order the update. This situation may occur when, for example, the server is not available)
- add async flush(Add async flush that performs operations optimally)

## Short description of the changes
- add system.timer.timer for async flush with interval
