### PR TITLE
Fix gRPC sender's parent span reference

### DIFF
--- a/src/Senders/Jaeger.Senders.Grpc/Protocols/JaegerGrpcSpanConverter.cs
+++ b/src/Senders/Jaeger.Senders.Grpc/Protocols/JaegerGrpcSpanConverter.cs
@@ -22,7 +22,6 @@ namespace Jaeger.Senders.Grpc.Protocols
             var duration = (span.FinishTimestampUtc ?? startTime) - startTime;
 
             var references = span.GetReferences();
-            var oneChildOfParent = references.Count == 1 && string.Equals(References.ChildOf, references[0].Type, StringComparison.Ordinal);
 
             var grpcSpan = new GrpcSpan
             {
@@ -32,7 +31,7 @@ namespace Jaeger.Senders.Grpc.Protocols
                 Flags = (uint)context.Flags,
                 StartTime = Timestamp.FromDateTime(startTime),
                 Duration = Duration.FromTimeSpan(duration),
-                References = { oneChildOfParent ? new List<GrpcReference>() : BuildReferences(references) },
+                References = { BuildReferences(references) },
                 Tags = { BuildTags(span.GetTags()) },
                 Logs = { BuildLogs(span.GetLogs()) }
             };

--- a/test/Senders/Jaeger.Senders.Grpc.Tests/Reporters/Protocols/JaegerGrpcSpanConverterTests.cs
+++ b/test/Senders/Jaeger.Senders.Grpc.Tests/Reporters/Protocols/JaegerGrpcSpanConverterTests.cs
@@ -1,8 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Google.Protobuf;
+using Jaeger.ApiV2;
 using Jaeger.Reporters;
 using Jaeger.Samplers;
 using Jaeger.Senders.Grpc.Protocols;
+using Jaeger.Util;
 using OpenTracing;
 using Xunit;
 using GrpcSpan = Jaeger.ApiV2.Span;
@@ -125,9 +129,8 @@ namespace Jaeger.Senders.Grpc.Tests.Reporters.Protocols
 
             GrpcSpan span = JaegerGrpcSpanConverter.ConvertSpan(child);
 
-            // TODO: Check ParentSpanID
-            //Assert.Equal((long)child.Context.ParentId, span.ParentSpanId);
-            Assert.Empty(span.References);
+            Assert.Single(span.References);
+            Assert.Equal(BuildReference(parent.Context, References.ChildOf), span.References[0]);
         }
 
         [Fact]
@@ -143,8 +146,6 @@ namespace Jaeger.Senders.Grpc.Tests.Reporters.Protocols
 
             GrpcSpan span = JaegerGrpcSpanConverter.ConvertSpan(child);
 
-            // TODO: Check ParentSpanID
-            //Assert.Equal(0, span.ParentSpanId);
             Assert.Equal(2, span.References.Count);
             Assert.Equal(BuildReference(parent.Context, References.ChildOf), span.References[0]);
             Assert.Equal(BuildReference(parent2.Context, References.ChildOf), span.References[1]);
@@ -163,8 +164,6 @@ namespace Jaeger.Senders.Grpc.Tests.Reporters.Protocols
 
             GrpcSpan span = JaegerGrpcSpanConverter.ConvertSpan(child);
 
-            // TODO: Check ParentSpanID
-            //Assert.Equal(0, span.ParentSpanId);
             Assert.Equal(2, span.References.Count);
             Assert.Equal(BuildReference(parent.Context, References.FollowsFrom), span.References[0]);
             Assert.Equal(BuildReference(parent2.Context, References.ChildOf), span.References[1]);


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #202 

## Short description of the changes
- The gRPC sender was missing the parent span id in it's references. This happend, since it was based on the Thrift sender, which has a separate field for the parent id. All references are now forwarded.
