### PR TITLE
Limit UDPs max span bytes when using Thrift

### DIFF
--- a/src/Communication/Jaeger.Communication.Thrift/Senders/ThriftSenderBase.cs
+++ b/src/Communication/Jaeger.Communication.Thrift/Senders/ThriftSenderBase.cs
@@ -21,8 +21,8 @@ namespace Jaeger.Thrift.Senders
 
         protected int MaxSpanBytes { get; }
 
-        /// <param name="protocolType">Protocol type (compact or binary)</param<
-        /// <param name="maxPacketSize">If 0 it will use default value <see cref="ThriftUdpTransport.MAX_PACKET_SIZE"/>.</param>
+        /// <param name="protocolType">Protocol type (compact or binary)</param>
+        /// <param name="maxPacketSize">If 0 it will use default value <see cref="ThriftUdpClientTransport.MaxPacketSize"/>.</param>
         public ThriftSenderBase(ProtocolType protocolType, int maxPacketSize)
         {
             switch (protocolType)

--- a/src/Senders/Jaeger.Senders.Thrift/UdpSender.cs
+++ b/src/Senders/Jaeger.Senders.Thrift/UdpSender.cs
@@ -36,11 +36,10 @@ namespace Jaeger.Senders.Thrift
 
         /// <param name="host">If empty it will use <see cref="DefaultAgentUdpHost"/>.</param>
         /// <param name="port">If 0 it will use <see cref="DefaultAgentUdpCompactPort"/>.</param>
-        /// <param name="maxPacketSize">If 0 it will use <see cref="ThriftUdpClientTransport.MaxPacketSize"/>.</param>
+        /// <param name="maxPacketSize">If 0 it will use <see cref="ThriftUdpClientTransport.MaxPacketSize"/>. Must not exceed <see cref="ThriftUdpClientTransport.MaxPacketSize"/>.</param>
         public UdpSender(string host, int port, int maxPacketSize)
             : base(ProtocolType.Compact, maxPacketSize)
         {
-
             if (string.IsNullOrEmpty(host))
             {
                 host = DefaultAgentUdpHost;
@@ -49,6 +48,12 @@ namespace Jaeger.Senders.Thrift
             if (port == 0)
             {
                 port = DefaultAgentUdpCompactPort;
+            }
+
+            if (maxPacketSize > ThriftUdpClientTransport.MaxPacketSize)
+            {
+                throw new NotSupportedException($"Using a packet size bigger than {ThriftUdpClientTransport.MaxPacketSize} "
+                                                + "can lead to lost traces and is therefore not supported.");
             }
 
             _udpTransport = new ThriftUdpClientTransport(host, port);

--- a/test/Senders/Jaeger.Senders.Thrift.Tests/UdpSenderTests.cs
+++ b/test/Senders/Jaeger.Senders.Thrift.Tests/UdpSenderTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Reflection;
+using Jaeger.Reporters;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTracing.Noop;
+using OpenTracing.Util;
+using Xunit;
+
+namespace Jaeger.Senders.Thrift.Tests
+{
+    public class UdpSenderTests
+    {
+        [Fact]
+        public void TestSenderWithAgentDataFromEnv()
+        {
+            Assert.Throws<NotSupportedException>(() => new UdpSender("jaeger-agent", 6832, 65535));
+        }
+    }
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #199

## Short description of the changes
- Values above 64k can lead to lost traces as shown by #199. To avoid users running into this issue when manually instantiating the `UdpSender`, the value is now limited.
