### PR TITLE
Update versions in example

### DIFF
--- a/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
+++ b/examples/Jaeger.Example.WebApi/Jaeger.Example.WebApi.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2" />
+    <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.7.1" />
 
     <!-- NOTE:
         In case you're building this application standalone, use below PackageReference 
         with an appropriate version instead of relative-path ProjectReference 
         to Jaeger project -->
-    <!-- PackageReference Include="Jaeger" Version="0.2.1" /-->
+    <!-- PackageReference Include="Jaeger" Version="1.0.2" /-->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #220 

## Short description of the changes
- The example had an old version. When following the instructions for standalone (using the NuGet package instead of the `ProjectReference`), it used a version not matching the code anymore.