### PR TITLE
Appropriately Set gRPC Client Max Send and Receive Message Length

### DIFF
--- a/src/Senders/Jaeger.Senders.Grpc/GrpcSender.cs
+++ b/src/Senders/Jaeger.Senders.Grpc/GrpcSender.cs
@@ -61,7 +61,13 @@ namespace Jaeger.Senders.Grpc
                 maxPacketSize = MaxPacketSize;
             }
 
-            _channel = new Channel(target, credentials);
+            var channelOptions = new List<ChannelOption>()
+            {
+                new ChannelOption(ChannelOptions.MaxSendMessageLength, maxPacketSize),
+                new ChannelOption(ChannelOptions.MaxReceiveMessageLength, maxPacketSize)
+            };
+
+            _channel = new Channel(target, credentials, channelOptions);
             _client = new CollectorService.CollectorServiceClient(_channel);
             _maxPacketSize = maxPacketSize;
         }


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
#225 

## Short description of the changes
Even though the GrpcSender allowed specifying a maxPacketSize
parameter if that value was over 4MB, Spans over that 4MB limit
would not be recorded because the core gRPC client library has a
default max message length of 4MB. Now, the GrpcSender will set
the appropriate ChannelOptions to set the MaxSendMessageLength and
MaxReceiveMessageLength based on the given maxPacketSize.

Signed-off-by: Justin Stauffer <justin@epic.com>
